### PR TITLE
Improve handling of disconnection and auto reconnect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,4 +65,4 @@ fastlane/screenshots
 fastlane/test_output
 
 # DS_Store
-Bluejay/.DS_Store
+.DS_Store

--- a/Bluejay/Bluejay/Bluejay.swift
+++ b/Bluejay/Bluejay/Bluejay.swift
@@ -666,6 +666,13 @@ extension Bluejay: CBCentralManagerDelegate {
     public func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Swift.Error?) {
         let backgroundTask =  UIApplication.shared.beginBackgroundTask(expirationHandler: nil)
         
+        /*
+         If Bluejay is not even connected when didDisconnectPeripheral is called (can happen when a pending connection is cancelled), Bluejay should not try to auto reconnect. Also, do not override if shouldAutoReconnect is already explicitly set to false from cancelEverything or from a manual disconnect.
+         */
+        if shouldAutoReconnect {
+            shouldAutoReconnect = connectedPeripheral != nil
+        }
+        
         let peripheralString = peripheral.name ?? peripheral.identifier.uuidString
         let errorString = error?.localizedDescription
         

--- a/Bluejay/Bluejay/Bluejay.swift
+++ b/Bluejay/Bluejay/Bluejay.swift
@@ -677,7 +677,7 @@ extension Bluejay: CBCentralManagerDelegate {
         }
         
         for observer in observers {
-            observer.weakReference?.disconnected()
+            observer.weakReference?.disconnected(from: Peripheral(bluejay: self, cbPeripheral: peripheral))
         }
         
         if !queue.isEmpty() {

--- a/Bluejay/Bluejay/Bluejay.swift
+++ b/Bluejay/Bluejay/Bluejay.swift
@@ -681,8 +681,8 @@ extension Bluejay: CBCentralManagerDelegate {
         }
         
         if !queue.isEmpty() {
-            // If Bluejay is currently disconnecting, the queue needs to process this disconnection event. Otherwise, this is an unexpected disconnection.
-            if isDisconnecting {
+            // If Bluejay is currently connecting or disconnecting, the queue needs to process this disconnection event. Otherwise, this is an unexpected disconnection.
+            if isConnecting || isDisconnecting {
                 queue.process(event: .didDisconnectPeripheral(peripheral), error: error as NSError?)
             }
             else {

--- a/Bluejay/Bluejay/Bluejay.swift
+++ b/Bluejay/Bluejay/Bluejay.swift
@@ -670,7 +670,7 @@ extension Bluejay: CBCentralManagerDelegate {
          If Bluejay is not even connected when didDisconnectPeripheral is called (can happen when a pending connection is cancelled), Bluejay should not try to auto reconnect. Also, do not override if shouldAutoReconnect is already explicitly set to false from cancelEverything or from a manual disconnect.
          */
         if shouldAutoReconnect {
-            shouldAutoReconnect = connectedPeripheral != nil
+            shouldAutoReconnect = isConnected
         }
         
         let peripheralString = peripheral.name ?? peripheral.identifier.uuidString

--- a/Bluejay/Bluejay/ConnectionObserver.swift
+++ b/Bluejay/Bluejay/ConnectionObserver.swift
@@ -12,7 +12,7 @@ import Foundation
     A protocol allowing conforming objects registered to Bluejay to optionally respond to Bluetooth connection events.
  
     - Attention
-    On initial subscription to Bluetooth events, `bluetoothAvailable(_ available: Bool)` will always be called immediately with whatever the current state is, and `connected(_ peripheral: BluejayPeripheral)` will also be called immediately if a device is already connected.
+    On initial subscription to Bluetooth events, `bluetoothAvailable(_ available: Bool)` will always be called immediately with whatever the current state is, and `connected(to peripheral: Peripheral)` will also be called immediately if a device is already connected.
 
     - Note
     Available callbacks:
@@ -30,14 +30,14 @@ public protocol ConnectionObserver: class {
     func disconnected(from peripheral: Peripheral)
 }
 
-/// Slightly less gross way to make the BluejayEventsObservable protocol's functions optional.
+/// Slightly less gross way to make the ConnectionObserver protocol's functions optional.
 extension ConnectionObserver {
     public func bluetoothAvailable(_ available: Bool) {}
     public func connected(to peripheral: Peripheral) {}
     public func disconnected(from peripheral: Peripheral) {}
 }
 
-/// Allows creating weak references to BluejayEventsObservable objects, so that the Bluejay singleton does not prevent the deallocation of those objects.
+/// Allows creating weak references to ConnectionObserver objects, so that the Bluejay singleton does not prevent the deallocation of those objects.
 struct WeakConnectionObserver {
     weak var weakReference: ConnectionObserver?
 }

--- a/Bluejay/Bluejay/ConnectionObserver.swift
+++ b/Bluejay/Bluejay/ConnectionObserver.swift
@@ -27,14 +27,14 @@ public protocol ConnectionObserver: class {
     */
     func bluetoothAvailable(_ available: Bool)
     func connected(to peripheral: Peripheral)
-    func disconnected()
+    func disconnected(from peripheral: Peripheral)
 }
 
 /// Slightly less gross way to make the BluejayEventsObservable protocol's functions optional.
 extension ConnectionObserver {
     public func bluetoothAvailable(_ available: Bool) {}
     public func connected(to peripheral: Peripheral) {}
-    public func disconnected() {}
+    public func disconnected(from peripheral: Peripheral) {}
 }
 
 /// Allows creating weak references to BluejayEventsObservable objects, so that the Bluejay singleton does not prevent the deallocation of those objects.

--- a/Bluejay/Bluejay/Queue.swift
+++ b/Bluejay/Bluejay/Queue.swift
@@ -104,7 +104,7 @@ class Queue {
                 queueable.fail(error)
             }
             else {
-                queueable.cancelled()
+                queueable.cancel()
             }            
         }
         

--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ The `ConnectionObserver` protocol allows a class to monitor and respond to major
 ```swift
 public protocol ConnectionObserver: class {
     func bluetoothAvailable(_ available: Bool)
-    func connected(_ peripheral: Peripheral)
-    func disconected()
+    func connected(to peripheral: Peripheral)
+    func disconnected(from peripheral: Peripheral)
 }
 ```
 


### PR DESCRIPTION
## Overview

Previously Bluejay doesn't quite understand why `didDisconnectPeripheral` is called, and therefore whenever it is called, sometimes it would trigger auto reconnect, sometimes it won't. This behaviour can be unpredictable in some cases, and cause unexpected re-connection attempts.

The issues centre around how `didDisconnectPeripheral` is multi-purpose and called by Core Bluetooth when you:

1. Cancel a pending connection
2. Cancel a connection to a connected peripheral (i.e. disconnect from it explicitly)
3. Loses connection to a connected peripheral unexpectedly (e.g. going out of range)

Only the 3rd case should trigger auto reconnect, but Bluejay also needs to figure out why `didDisconnectPeripheral` is called.

## Solutions

### 1 - Cancel a pending connection

To figure out the first case: use the `isConnecting` state, and have the `Connection` operation that's in-flight **wait** for the `didDisconnectPeripheral` callback before calling completion.

**Note:** As the the queue is FIFO and serial, and if `isConnecting` is true, the current operation has to be the pending connection task.

**Additionally:** A pending connection can be cancelled if it times out, or if `cancelEverything` with or without an error is called by the user.

### 2 - Explicit disconnection request

To figure out the second case: use the `isDisconnecting` state, as explicit calls to disconnect should always set that flag.

### 3 - Unexpected disconnection

To figure out the third case: use the `isConnected` state, as `shouldAutoReconnect` should definitely be true if Bluejay was connected just before `didDisconnectPeripheral` is called, **and** if there wasn't an explicit disconnection request when this happen.