### PR TITLE
Prevent calling API on Bluejay while a background task is running

### DIFF
--- a/Bluejay/Bluejay/Bluejay.swift
+++ b/Bluejay/Bluejay/Bluejay.swift
@@ -237,6 +237,8 @@ public class Bluejay: NSObject {
         )
     {
         if isRunningBackgroundTask {
+            // Terminate the app if this is called from the same thread as the running background task.
+            Dispatch.dispatchPrecondition(condition: .notOnQueue(DispatchQueue.global()))
             log("Warning: You cannot start a scan while a background task is still running.")
             return
         }
@@ -257,6 +259,8 @@ public class Bluejay: NSObject {
     /// Stops an ongoing scan if there is one, otherwise it does nothing.
     public func stopScanning() {
         if isRunningBackgroundTask {
+            // Terminate the app if this is called from the same thread as the running background task.
+            Dispatch.dispatchPrecondition(condition: .notOnQueue(DispatchQueue.global()))
             log("Warning: You cannot stop a scan while a background task is still running.")
             return
         }
@@ -275,6 +279,8 @@ public class Bluejay: NSObject {
     */
     public func connect(_ peripheralIdentifier: PeripheralIdentifier, completion: @escaping (ConnectionResult) -> Void) {
         if isRunningBackgroundTask {
+            // Terminate the app if this is called from the same thread as the running background task.
+            Dispatch.dispatchPrecondition(condition: .notOnQueue(DispatchQueue.global()))
             completion(.failure(Error.backgroundTaskRunning()))
             return
         }
@@ -301,6 +307,8 @@ public class Bluejay: NSObject {
     */
     public func disconnect(completion: ((DisconnectionResult) -> Void)? = nil) {
         if isRunningBackgroundTask {
+            // Terminate the app if this is called from the same thread as the running background task.
+            Dispatch.dispatchPrecondition(condition: .notOnQueue(DispatchQueue.global()))
             log("Warning: You've tried to disconnect while a background task is still running. The disconnect call will either do nothing, or fail if a completion block is provided.")
             completion?(.failure(Error.backgroundTaskRunning()))
             return
@@ -352,6 +360,8 @@ public class Bluejay: NSObject {
     */
     public func read<R: Receivable>(from characteristicIdentifier: CharacteristicIdentifier, completion: @escaping (ReadResult<R>) -> Void) {
         if isRunningBackgroundTask {
+            // Terminate the app if this is called from the same thread as the running background task.
+            Dispatch.dispatchPrecondition(condition: .notOnQueue(DispatchQueue.global()))
             completion(.failure(Error.backgroundTaskRunning()))
             return
         }
@@ -373,6 +383,8 @@ public class Bluejay: NSObject {
     */
     public func write<S: Sendable>(to characteristicIdentifier: CharacteristicIdentifier, value: S, completion: @escaping (WriteResult) -> Void) {
         if isRunningBackgroundTask {
+            // Terminate the app if this is called from the same thread as the running background task.
+            Dispatch.dispatchPrecondition(condition: .notOnQueue(DispatchQueue.global()))
             completion(.failure(Error.backgroundTaskRunning()))
             return
         }
@@ -394,6 +406,8 @@ public class Bluejay: NSObject {
      */
     public func listen<R: Receivable>(to characteristicIdentifier: CharacteristicIdentifier, completion: @escaping (ReadResult<R>) -> Void) {
         if isRunningBackgroundTask {
+            // Terminate the app if this is called from the same thread as the running background task.
+            Dispatch.dispatchPrecondition(condition: .notOnQueue(DispatchQueue.global()))
             completion(.failure(Error.backgroundTaskRunning()))
             return
         }
@@ -415,6 +429,8 @@ public class Bluejay: NSObject {
     */
     public func endListen(to characteristicIdentifier: CharacteristicIdentifier, completion: ((WriteResult) -> Void)? = nil) {
         if isRunningBackgroundTask {
+            // Terminate the app if this is called from the same thread as the running background task.
+            Dispatch.dispatchPrecondition(condition: .notOnQueue(DispatchQueue.global()))
             log("Warning: You've tried to end a listen while a background task is still running. The endListen call will either do nothing, or fail if a completion block is provided.")
             completion?(.failure(Error.backgroundTaskRunning()))
             return
@@ -437,6 +453,8 @@ public class Bluejay: NSObject {
     */
     public func restoreListen<R: Receivable>(to characteristicIdentifier: CharacteristicIdentifier, completion: @escaping (ReadResult<R>) -> Void) {
         if isRunningBackgroundTask {
+            // Terminate the app if this is called from the same thread as the running background task.
+            Dispatch.dispatchPrecondition(condition: .notOnQueue(DispatchQueue.global()))
             completion(.failure(Error.backgroundTaskRunning()))
             return
         }

--- a/Bluejay/Bluejay/Error.swift
+++ b/Bluejay/Bluejay/Error.swift
@@ -141,4 +141,20 @@ struct Error {
         )
     }
     
+    static func backgroundTaskRunning() -> NSError {
+        return NSError(
+            domain: "Bluejay",
+            code: 16,
+            userInfo: [NSLocalizedDescriptionKey: "Regular Bluetooth operation is not available when a background task is running. For reading, writing, and listening, please use only the API found in the Synchronized Peripheral provided to you when working inside a background task block."]
+        )
+    }
+    
+    static func multipleBackgroundTask() -> NSError {
+        return NSError(
+            domain: "Bluejay",
+            code: 17,
+            userInfo: [NSLocalizedDescriptionKey: "Multiple background task is not supported."]
+        )
+    }
+    
 }


### PR DESCRIPTION
It is best to only work with the synchronized peripheral while inside a background task. It is usually a programmer error to try to access something from the Bluejay interface while inside a background task, or an attempt to try to use the background task for something it is not designed for.

This PR adds some protection against doing things like calling `bluejay.write/read/listen`, or even `bluejay.scan` and `bluejay.disconnect` inside a background task. Doing so will either result in the incorrect calls failing immediately with the appropriate error, or not doing anything at all. In the latter case, a warning is printed to the console.

Additionally, I've added protection against calling `run:backgroundTask:...` simultaneously, or in close succession before the first one finishes. Only one execution of a background task is allowed at a time for simplicity.