### PR TITLE
Fix caching of listens and add a bit of support for managing cached listens

### DIFF
--- a/Bluejay/Bluejay/Bluejay.swift
+++ b/Bluejay/Bluejay/Bluejay.swift
@@ -695,7 +695,9 @@ extension Bluejay: CBCentralManagerDelegate {
         }
         
         for observer in observers {
-            observer.weakReference?.disconnected(from: Peripheral(bluejay: self, cbPeripheral: peripheral))
+            let disconnectedPeripheral = connectingPeripheral ?? connectedPeripheral
+            precondition(disconnectedPeripheral != nil, "Disconnected from an unexpected peripheral.")
+            observer.weakReference?.disconnected(from: disconnectedPeripheral!)
         }
         
         if !queue.isEmpty() {

--- a/Bluejay/Bluejay/Bluejay.swift
+++ b/Bluejay/Bluejay/Bluejay.swift
@@ -182,6 +182,17 @@ public class Bluejay: NSObject {
         connectedPeripheral = nil
     }
     
+    /**
+     This will stop the listening on all subscribed characteristics.
+     
+     - Parameter error: If nil, all listen callbacks will be cancelled without any errors. If an error is provided, all listen callbacks will be failed with the supplied error.
+     */
+    public func cancelAllListens(_ error: NSError? = nil) {
+        if let connectedPeripheral = connectedPeripheral {
+            connectedPeripheral.cancelAllListens(error)
+        }
+    }
+    
     // MARK: - Events Registration
     
     /**

--- a/Bluejay/Bluejay/Bluejay.swift
+++ b/Bluejay/Bluejay/Bluejay.swift
@@ -176,24 +176,10 @@ public class Bluejay: NSObject {
     public func cancelEverything(_ error: NSError? = nil) {
         shouldAutoReconnect = false
 
-        cancelAllListens(error)
         queue.cancelAll(error)
         
         if isConnected {
             cbCentralManager.cancelPeripheralConnection(connectedPeripheral!.cbPeripheral)
-        }
-    }
-    
-    /**
-     This will cancel the listening on all subscribed characteristics.
-     
-     - Important: This does not remove any cached listens for state restoration. Use `clearListeCaches` to explicitly remove all cached listens for state restoration, or use `endListen` to stop a specific listen in addition to removing it from the cache for state restoration.
-     
-     - Parameter error: If nil, all listen callbacks will be cancelled without any errors. If an error is provided, all listen callbacks will be failed with the supplied error.
-     */
-    public func cancelAllListens(_ error: NSError? = nil) {
-        if let connectedPeripheral = connectedPeripheral {
-            connectedPeripheral.cancelAllListens(error)
         }
     }
     

--- a/Bluejay/Bluejay/Bluejay.swift
+++ b/Bluejay/Bluejay/Bluejay.swift
@@ -179,9 +179,6 @@ public class Bluejay: NSObject {
         if isConnected {
             cbCentralManager.cancelPeripheralConnection(connectedPeripheral!.cbPeripheral)
         }
-        
-        connectingPeripheral = nil
-        connectedPeripheral = nil
     }
     
     /**

--- a/Bluejay/Bluejay/Bluejay.swift
+++ b/Bluejay/Bluejay/Bluejay.swift
@@ -21,9 +21,6 @@ public class Bluejay: NSObject {
     /// Internal reference to CoreBluetooth's CBCentralManager.
     fileprivate var cbCentralManager: CBCentralManager!
     
-    /// The value for CBCentralManagerOptionRestoreIdentifierKey.
-    fileprivate var restoreIdentifier: String?
-    
     /// List of weak references to objects interested in receiving notifications on Bluetooth connection events and state changes.
     fileprivate var observers = [WeakConnectionObserver]()
     
@@ -42,9 +39,6 @@ public class Bluejay: NSObject {
     /// Reference to the peripheral identifier used for supporting state restoration.
     fileprivate var peripheralIdentifierToRestore: PeripheralIdentifier?
     
-    /// Reference to the object capable of restoring listens during state restoration.
-    fileprivate var listenRestorer: WeakListenRestorer?
-    
     /// Determines whether state restoration is allowed.
     fileprivate var shouldRestoreState = false
     
@@ -52,6 +46,12 @@ public class Bluejay: NSObject {
     
     /// Contains the operations to execute in FIFO order.
     var queue: Queue!
+    
+    /// The value for CBCentralManagerOptionRestoreIdentifierKey.
+    var restoreIdentifier: RestoreIdentifier?
+    
+    /// Reference to the object capable of restoring listens during state restoration.
+    var listenRestorer: WeakListenRestorer?
     
     // MARK: - Public Properties
     
@@ -136,13 +136,15 @@ public class Bluejay: NSObject {
         switch restoreMode {
         case .disable:
             break
-        case .enable(let restoreIdentifier):
+        case .enable(let restoreID):
             checkBackgroundSupportForBluetooth()
+            restoreIdentifier = restoreID
             options[CBCentralManagerOptionRestoreIdentifierKey] = restoreIdentifier
-        case .enableWithListenRestorer(let restoreIdentifier, let restorer):
+        case .enableWithListenRestorer(let restoreID, let restorer):
             checkBackgroundSupportForBluetooth()
-            options[CBCentralManagerOptionRestoreIdentifierKey] = restoreIdentifier
+            restoreIdentifier = restoreID
             listenRestorer = WeakListenRestorer(weakReference: restorer)
+            options[CBCentralManagerOptionRestoreIdentifierKey] = restoreIdentifier
         }
         
         cbCentralManager = CBCentralManager(

--- a/Bluejay/Bluejay/Bluejay.swift
+++ b/Bluejay/Bluejay/Bluejay.swift
@@ -176,6 +176,7 @@ public class Bluejay: NSObject {
     public func cancelEverything(_ error: NSError? = nil) {
         shouldAutoReconnect = false
 
+        cancelAllListens(error)
         queue.cancelAll(error)
         
         if isConnected {

--- a/Bluejay/Bluejay/Peripheral.swift
+++ b/Bluejay/Bluejay/Peripheral.swift
@@ -44,7 +44,7 @@ public class Peripheral: NSObject {
     
     // MARK: - Operations
     
-    func cancelAllOperations(_ error: NSError? = nil) {
+    func cancelAllListens(_ error: NSError? = nil) {
         for callback in listeners.values {
             if let error = error {
                 callback(.failure(error))
@@ -55,12 +55,6 @@ public class Peripheral: NSObject {
         }
         
         listeners = [:]
-        
-        guard let bluejay = bluejay else {
-            preconditionFailure("Cannot cancel all operations: Bluejay is nil.")
-        }
-        
-        bluejay.queue.cancelAll(error)
     }
     
     private func updateOperations() {

--- a/Bluejay/Bluejay/Peripheral.swift
+++ b/Bluejay/Bluejay/Peripheral.swift
@@ -32,6 +32,10 @@ public class Peripheral: NSObject {
         self.cbPeripheral.delegate = self
     }
     
+    deinit {
+        log("Deinit peripheral: \(String(describing: cbPeripheral.name ?? cbPeripheral.identifier.uuidString))")
+    }
+    
     // MARK: - Attributes
     
     public var uuid: PeripheralIdentifier {

--- a/Bluejay/Bluejay/Peripheral.swift
+++ b/Bluejay/Bluejay/Peripheral.swift
@@ -378,7 +378,7 @@ extension Peripheral: CBPeripheralDelegate {
                 return characteristicIdentifier.uuid.uuidString == characteristic.uuid.uuidString
             })
             
-            let isReadUnhandled = isCancellingListenOnCurrentRead || bluejay.queue.isEmpty()
+            let isReadUnhandled = isCancellingListenOnCurrentRead || (listeners.isEmpty && bluejay.queue.isEmpty())
             
             if isReadUnhandled {
                 return

--- a/Bluejay/Bluejay/Peripheral.swift
+++ b/Bluejay/Bluejay/Peripheral.swift
@@ -47,20 +47,7 @@ public class Peripheral: NSObject {
     }
     
     // MARK: - Operations
-    
-    func cancelAllListens(_ error: NSError? = nil) {
-        for callback in listeners.values {
-            if let error = error {
-                callback(.failure(error))
-            }
-            else {
-                callback(.cancelled)
-            }
-        }
         
-        listeners = [:]
-    }
-    
     private func updateOperations() {
         guard let bluejay = bluejay else {
             preconditionFailure("Cannot update operation: Bluejay is nil.")

--- a/Bluejay/Bluejay/Peripheral.swift
+++ b/Bluejay/Bluejay/Peripheral.swift
@@ -203,11 +203,16 @@ public class Peripheral: NSObject {
                         completion(ReadResult<R>(dataResult: dataResult))
                     }
                     
-                    // Make sure a successful listen is cached, so Bluejay can inform which characteristics need their listens restored on state restoration.
-                    weakSelf.cache(listeningCharacteristic: characteristicIdentifier)
+                    // Only bother caching if listen restoration is enabled.
+                    if
+                        let restoreIdentifier = weakSelf.bluejay?.restoreIdentifier,
+                        weakSelf.bluejay?.listenRestorer != nil
+                    {
+                        // Make sure a successful listen is cached, so Bluejay can inform its delegate on which characteristics need their listens restored during state restoration.
+                        weakSelf.cache(listeningCharacteristic: characteristicIdentifier, restoreIdentifier: restoreIdentifier)
+                    }
                 case .cancelled:
                     completion(.cancelled)
-                    weakSelf.remove(listeningCharacteristic: characteristicIdentifier)
                 case .failure(let error):
                     completion(.failure(error))
                 }
@@ -244,10 +249,16 @@ public class Peripheral: NSObject {
                         listenCallback?(.cancelled)
                     }
                     
-                    completion?(result)
+                    // Only bother removing the listen cache if listen restoration is enabled.
+                    if
+                        let restoreIdentifier = weakSelf.bluejay?.restoreIdentifier,
+                        weakSelf.bluejay?.listenRestorer != nil
+                    {
+                        // Make sure an ended listen does not exist in the cache, as we don't want to restore a cancelled listen on state restoration.
+                        weakSelf.remove(listeningCharacteristic: characteristicIdentifier, restoreIdentifier: restoreIdentifier)
+                    }
                     
-                    // Make sure an ended listen does not exist in the cache, as we don't want to restore a cancelled listen on state restoration.
-                    weakSelf.remove(listeningCharacteristic: characteristicIdentifier)
+                    completion?(result)
                 }))
         })
     }
@@ -262,72 +273,54 @@ public class Peripheral: NSObject {
         listeners[characteristicIdentifier] = { dataResult in
             completion(ReadResult<R>(dataResult: dataResult))
         }
-        
-        // Make sure restored listens are cached again for future restoration. The cache method will handle any duplicate uuid, so this sanity check should not create any redundancy.
-        cache(listeningCharacteristic: characteristicIdentifier)
     }
     
-    private func cache(listeningCharacteristic: CharacteristicIdentifier) {
-        guard let bluejay = bluejay else {
-            preconditionFailure("Cannot cache listening on: \(listeningCharacteristic.uuid.uuidString): Bluejay is nil.")
-        }
-        
+    // MARK: - Listen Caching
+    
+    private func cache(listeningCharacteristic: CharacteristicIdentifier, restoreIdentifier: RestoreIdentifier) {
         let serviceUUID = listeningCharacteristic.service.uuid.uuidString
         let characteristicUUID = listeningCharacteristic.uuid.uuidString
         
-        // Create a new entry in user defaults if none exists.
-        guard let listenCaches = UserDefaults.standard.dictionary(forKey: Constant.listenCaches) else {
-            let cacheData = NSKeyedArchiver.archivedData(
-                withRootObject: ListenCache(serviceUUID: serviceUUID, characteristicUUID: characteristicUUID).encoded!
-            )
-            
-            UserDefaults.standard.set([bluejay.uuid.uuidString : [cacheData]], forKey: Constant.listenCaches)
-            UserDefaults.standard.synchronize()
-            return
-        }
-        
-        // Create a new listen cache if none exists.
-        guard
-            let listenCacheData = listenCaches[bluejay.uuid.uuidString] as? [Data]
-        else {
-            let cacheData = NSKeyedArchiver.archivedData(
-                withRootObject: ListenCache(serviceUUID: serviceUUID, characteristicUUID: characteristicUUID).encoded!
-            )
-            
-            var newListenCaches = listenCaches
-            newListenCaches[bluejay.uuid.uuidString] = [cacheData]
-            
-            UserDefaults.standard.set(newListenCaches, forKey: Constant.listenCaches)
-            UserDefaults.standard.synchronize()
-            return
-        }
-        
-        // Add to existing listen cache.
         let cacheData = NSKeyedArchiver.archivedData(
             withRootObject: ListenCache(serviceUUID: serviceUUID, characteristicUUID: characteristicUUID).encoded!
         )
         
-        var newListenCacheData = listenCacheData
-        newListenCacheData.append(cacheData)
-        
-        var newListenCaches = listenCaches
-        newListenCaches[bluejay.uuid.uuidString] = newListenCacheData
-        
-        UserDefaults.standard.set(newListenCaches, forKey: Constant.listenCaches)
-        UserDefaults.standard.synchronize()
-    }
-    
-    private func remove(listeningCharacteristic: CharacteristicIdentifier) {
-        guard let bluejay = bluejay else {
-            preconditionFailure("Cannot remove listening on \(listeningCharacteristic.uuid.uuidString): Bluejay is nil.")
+        // If the UserDefaults for the specified restore identifier doesn't exist yet, create one and add the ListenCache to it.
+        guard
+            let listenCaches = UserDefaults.standard.dictionary(forKey: Constant.listenCaches),
+            let listenCacheData = listenCaches[restoreIdentifier] as? [Data]
+        else
+        {
+            UserDefaults.standard.set([restoreIdentifier : [cacheData]], forKey: Constant.listenCaches)
+            UserDefaults.standard.synchronize()
+            
+            return
         }
         
+        // If the ListenCache already exists, don't add it to the cache again.
+        if listenCacheData.contains(cacheData) {
+            return
+        }
+        else {
+            // Add the ListenCache to the existing UserDefaults for the specified restore identifier.
+            var newListenCacheData = listenCacheData
+            newListenCacheData.append(cacheData)
+            
+            var newListenCaches = listenCaches
+            newListenCaches[restoreIdentifier] = newListenCacheData
+            
+            UserDefaults.standard.set(newListenCaches, forKey: Constant.listenCaches)
+            UserDefaults.standard.synchronize()
+        }
+    }
+    
+    private func remove(listeningCharacteristic: CharacteristicIdentifier, restoreIdentifier: RestoreIdentifier) {
         let serviceUUID = listeningCharacteristic.service.uuid.uuidString
         let characteristicUUID = listeningCharacteristic.uuid.uuidString
         
         guard
             let listenCaches = UserDefaults.standard.dictionary(forKey: Constant.listenCaches),
-            let cacheData = listenCaches[bluejay.uuid.uuidString] as? [Data]
+            let cacheData = listenCaches[restoreIdentifier] as? [Data]
         else {
             // Nothing to remove.
             return
@@ -335,14 +328,20 @@ public class Peripheral: NSObject {
         
         var newCacheData = cacheData
         newCacheData = newCacheData.filter { (data) -> Bool in
-            let listenCache = (NSKeyedUnarchiver.unarchiveObject(with: data) as? (ListenCache.Coding))!
-                .decoded as! ListenCache
+            let listenCache = (NSKeyedUnarchiver.unarchiveObject(with: data) as? (ListenCache.Coding))!.decoded as! ListenCache
             return (listenCache.serviceUUID != serviceUUID) && (listenCache.characteristicUUID != characteristicUUID)
         }
         
         var newListenCaches = listenCaches
-        newListenCaches[bluejay.uuid.uuidString] = newCacheData
-
+        
+        // If the new cache data is empty after the filter removal, remove the entire cache entry for the specified restore identifier as well.
+        if newCacheData.isEmpty {
+            newListenCaches.removeValue(forKey: restoreIdentifier)
+        }
+        else {
+            newListenCaches[restoreIdentifier] = newCacheData
+        }
+        
         UserDefaults.standard.set(newListenCaches, forKey: Constant.listenCaches)
         UserDefaults.standard.synchronize()
         

--- a/Bluejay/BluejayDemo/HeartSensorViewController.swift
+++ b/Bluejay/BluejayDemo/HeartSensorViewController.swift
@@ -314,8 +314,6 @@ extension HeartSensorViewController: ConnectionObserver {
         statusCell.detailTextLabel?.text = "Disconnected"
         bpmCell.detailTextLabel?.text = "0"
         sensorLocationCell.detailTextLabel?.text = "Unknown"
-        
-        stopMonitoringHeartRate()
     }
         
 }

--- a/Bluejay/BluejayDemo/HeartSensorViewController.swift
+++ b/Bluejay/BluejayDemo/HeartSensorViewController.swift
@@ -308,14 +308,14 @@ extension HeartSensorViewController: ConnectionObserver {
         readSensorLocation()
     }
     
-    func disconnected() {
+    func disconnected(from peripheral: Peripheral) {
         isMonitoringHeartRate = false
-
+        
         statusCell.detailTextLabel?.text = "Disconnected"
         bpmCell.detailTextLabel?.text = "0"
         sensorLocationCell.detailTextLabel?.text = "Unknown"
         
         stopMonitoringHeartRate()
     }
-    
+        
 }

--- a/Bluejay/BluejayDemo/HeartSensorViewController.swift
+++ b/Bluejay/BluejayDemo/HeartSensorViewController.swift
@@ -20,7 +20,6 @@ class HeartSensorViewController: UITableViewController {
     @IBOutlet var sensorLocationCell: UITableViewCell!
     @IBOutlet var connectCell: UITableViewCell!
     @IBOutlet var disconnectCell: UITableViewCell!
-    @IBOutlet var cancelAllListensCell: UITableViewCell!
     @IBOutlet var startMonitoringCell: UITableViewCell!
     @IBOutlet var resetCell: UITableViewCell!
     @IBOutlet var cancelEverythingCell: UITableViewCell!
@@ -220,15 +219,6 @@ class HeartSensorViewController: UITableViewController {
         }
     }
     
-    private func cancelAllListens() {
-        guard let bluejay = bluejay else {
-            showBluejayMissingAlert()
-            return
-        }
-        
-        bluejay.cancelAllListens()
-    }
-    
     private func reset() {
         guard let bluejay = bluejay else {
             showBluejayMissingAlert()
@@ -302,9 +292,6 @@ class HeartSensorViewController: UITableViewController {
             }
             else if selectedCell == disconnectCell {
                 disconnect()
-            }
-            else if selectedCell == cancelAllListensCell {
-                cancelAllListens()
             }
             else if selectedCell == startMonitoringCell {
                 startMonitoringHeartRate()

--- a/Bluejay/BluejayDemo/HeartSensorViewController.swift
+++ b/Bluejay/BluejayDemo/HeartSensorViewController.swift
@@ -23,6 +23,7 @@ class HeartSensorViewController: UITableViewController {
     @IBOutlet var cancelAllListensCell: UITableViewCell!
     @IBOutlet var startMonitoringCell: UITableViewCell!
     @IBOutlet var resetCell: UITableViewCell!
+    @IBOutlet var cancelEverythingCell: UITableViewCell!
     
     fileprivate var isMonitoringHeartRate = false
     
@@ -278,6 +279,15 @@ class HeartSensorViewController: UITableViewController {
         }
     }
     
+    private func cancelEverything() {
+        guard let bluejay = bluejay else {
+            showBluejayMissingAlert()
+            return
+        }
+     
+        bluejay.cancelEverything()
+    }
+    
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         
@@ -301,6 +311,9 @@ class HeartSensorViewController: UITableViewController {
             }
             else if selectedCell == resetCell {
                 reset()
+            }
+            else if selectedCell == cancelEverythingCell {
+                cancelEverything()
             }
         }
     }

--- a/Bluejay/BluejayDemo/HeartSensorViewController.swift
+++ b/Bluejay/BluejayDemo/HeartSensorViewController.swift
@@ -20,6 +20,8 @@ class HeartSensorViewController: UITableViewController {
     @IBOutlet var sensorLocationCell: UITableViewCell!
     @IBOutlet var connectCell: UITableViewCell!
     @IBOutlet var disconnectCell: UITableViewCell!
+    @IBOutlet var cancelAllListensCell: UITableViewCell!
+    @IBOutlet var startMonitoringCell: UITableViewCell!
     @IBOutlet var resetCell: UITableViewCell!
     
     fileprivate var isMonitoringHeartRate = false
@@ -217,6 +219,15 @@ class HeartSensorViewController: UITableViewController {
         }
     }
     
+    private func cancelAllListens() {
+        guard let bluejay = bluejay else {
+            showBluejayMissingAlert()
+            return
+        }
+        
+        bluejay.cancelAllListens()
+    }
+    
     private func reset() {
         guard let bluejay = bluejay else {
             showBluejayMissingAlert()
@@ -281,6 +292,12 @@ class HeartSensorViewController: UITableViewController {
             }
             else if selectedCell == disconnectCell {
                 disconnect()
+            }
+            else if selectedCell == cancelAllListensCell {
+                cancelAllListens()
+            }
+            else if selectedCell == startMonitoringCell {
+                startMonitoringHeartRate()
             }
             else if selectedCell == resetCell {
                 reset()

--- a/Bluejay/BluejayDemo/Main.storyboard
+++ b/Bluejay/BluejayDemo/Main.storyboard
@@ -272,6 +272,23 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" textLabel="PGA-JM-KFh" style="IBUITableViewCellStyleDefault" id="8gu-dL-BbQ">
+                                        <rect key="frame" x="0.0" y="463.5" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="8gu-dL-BbQ" id="wKj-am-k4k">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Cancel Everything" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="PGA-JM-KFh">
+                                                    <rect key="frame" x="15" y="0.0" width="345" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
                                 </cells>
                             </tableViewSection>
                         </sections>
@@ -284,6 +301,7 @@
                     <connections>
                         <outlet property="bpmCell" destination="Db0-xu-drE" id="mIb-t9-nzJ"/>
                         <outlet property="cancelAllListensCell" destination="Avl-Xh-Q46" id="2j4-RF-ufI"/>
+                        <outlet property="cancelEverythingCell" destination="8gu-dL-BbQ" id="GBt-Ct-RLy"/>
                         <outlet property="connectCell" destination="R2E-AD-cT8" id="LOc-cD-Oxu"/>
                         <outlet property="disconnectCell" destination="1op-Zm-lCj" id="a2I-J5-pAH"/>
                         <outlet property="resetCell" destination="XiN-De-pYv" id="VG8-cG-l4w"/>

--- a/Bluejay/BluejayDemo/Main.storyboard
+++ b/Bluejay/BluejayDemo/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Wg8-1U-aZL">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16G29" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Wg8-1U-aZL">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -221,25 +221,8 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" textLabel="2dt-sw-8OL" style="IBUITableViewCellStyleDefault" id="Avl-Xh-Q46">
-                                        <rect key="frame" x="0.0" y="331.5" width="375" height="44"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Avl-Xh-Q46" id="pHR-37-0ul">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Cancel All Listens" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="2dt-sw-8OL">
-                                                    <rect key="frame" x="15" y="0.0" width="345" height="43.5"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                            </subviews>
-                                        </tableViewCellContentView>
-                                    </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" textLabel="7Fv-tE-bSY" style="IBUITableViewCellStyleDefault" id="Lo1-ee-VZX">
-                                        <rect key="frame" x="0.0" y="375.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="331.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Lo1-ee-VZX" id="sLg-0u-US4">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -256,7 +239,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" textLabel="qBH-HD-97n" style="IBUITableViewCellStyleDefault" id="XiN-De-pYv">
-                                        <rect key="frame" x="0.0" y="419.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="375.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="XiN-De-pYv" id="pqL-6l-Cbg">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -273,7 +256,7 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" textLabel="PGA-JM-KFh" style="IBUITableViewCellStyleDefault" id="8gu-dL-BbQ">
-                                        <rect key="frame" x="0.0" y="463.5" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="419.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="8gu-dL-BbQ" id="wKj-am-k4k">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -300,7 +283,6 @@
                     <navigationItem key="navigationItem" title="Heart Sensor" id="wGi-uL-yJU"/>
                     <connections>
                         <outlet property="bpmCell" destination="Db0-xu-drE" id="mIb-t9-nzJ"/>
-                        <outlet property="cancelAllListensCell" destination="Avl-Xh-Q46" id="2j4-RF-ufI"/>
                         <outlet property="cancelEverythingCell" destination="8gu-dL-BbQ" id="GBt-Ct-RLy"/>
                         <outlet property="connectCell" destination="R2E-AD-cT8" id="LOc-cD-Oxu"/>
                         <outlet property="disconnectCell" destination="1op-Zm-lCj" id="a2I-J5-pAH"/>

--- a/Bluejay/BluejayDemo/Main.storyboard
+++ b/Bluejay/BluejayDemo/Main.storyboard
@@ -221,8 +221,42 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" textLabel="qBH-HD-97n" style="IBUITableViewCellStyleDefault" id="XiN-De-pYv">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" textLabel="2dt-sw-8OL" style="IBUITableViewCellStyleDefault" id="Avl-Xh-Q46">
                                         <rect key="frame" x="0.0" y="331.5" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Avl-Xh-Q46" id="pHR-37-0ul">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Cancel All Listens" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="2dt-sw-8OL">
+                                                    <rect key="frame" x="15" y="0.0" width="345" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" textLabel="7Fv-tE-bSY" style="IBUITableViewCellStyleDefault" id="Lo1-ee-VZX">
+                                        <rect key="frame" x="0.0" y="375.5" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Lo1-ee-VZX" id="sLg-0u-US4">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Start Monitoring" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="7Fv-tE-bSY">
+                                                    <rect key="frame" x="15" y="0.0" width="345" height="43.5"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" textLabel="qBH-HD-97n" style="IBUITableViewCellStyleDefault" id="XiN-De-pYv">
+                                        <rect key="frame" x="0.0" y="419.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="XiN-De-pYv" id="pqL-6l-Cbg">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -249,10 +283,12 @@
                     <navigationItem key="navigationItem" title="Heart Sensor" id="wGi-uL-yJU"/>
                     <connections>
                         <outlet property="bpmCell" destination="Db0-xu-drE" id="mIb-t9-nzJ"/>
+                        <outlet property="cancelAllListensCell" destination="Avl-Xh-Q46" id="2j4-RF-ufI"/>
                         <outlet property="connectCell" destination="R2E-AD-cT8" id="LOc-cD-Oxu"/>
                         <outlet property="disconnectCell" destination="1op-Zm-lCj" id="a2I-J5-pAH"/>
                         <outlet property="resetCell" destination="XiN-De-pYv" id="VG8-cG-l4w"/>
                         <outlet property="sensorLocationCell" destination="SmU-Xg-frL" id="pSB-wT-aXf"/>
+                        <outlet property="startMonitoringCell" destination="Lo1-ee-VZX" id="Bvg-v2-3L8"/>
                         <outlet property="statusCell" destination="rxx-gz-fW1" id="Jny-7J-xNh"/>
                         <segue destination="bKX-W4-lcD" kind="show" identifier="showSensorLocation" id="Dfy-0Y-IqM"/>
                     </connections>

--- a/Bluejay/BluejayDemo/ScanHeartRateSensorsViewController.swift
+++ b/Bluejay/BluejayDemo/ScanHeartRateSensorsViewController.swift
@@ -81,7 +81,11 @@ class ScanHeartRateSensorsViewController: UITableViewController {
                 
                 switch result {
                 case .success:
-                    weakSelf.scanHeartSensors()
+                    if !weakSelf.bluejay.isScanning {
+                        DispatchQueue.main.async {
+                            weakSelf.scanHeartSensors()
+                        }
+                    }
                 case .cancelled:
                     preconditionFailure("Disconnection cancelled unexpectedly.")
                 case .failure(let error):

--- a/Bluejay/BluejayDemo/ScanHeartRateSensorsViewController.swift
+++ b/Bluejay/BluejayDemo/ScanHeartRateSensorsViewController.swift
@@ -28,7 +28,7 @@ class ScanHeartRateSensorsViewController: UITableViewController {
         
         clearsSelectionOnViewWillAppear = true
         
-        bluejay.start(connectionObserver: self)
+        bluejay.start(connectionObserver: self, backgroundRestore: .enableWithListenRestorer("com.steamclock.bluejay", self))
         
         scanHeartSensors()
     }
@@ -165,6 +165,14 @@ extension ScanHeartRateSensorsViewController: ConnectionObserver {
     
     func disconnected() {
         debugPrint("Disconnected")
+    }
+    
+}
+
+extension ScanHeartRateSensorsViewController: ListenRestorer {
+    
+    func willRestoreListen(on characteristic: CharacteristicIdentifier) -> Bool {
+        return false
     }
     
 }


### PR DESCRIPTION
## Overview

This PR fixes the caching of listens for listen restoration, and adds a bit of support for managing those cached listens. It's only "a bit" because there are some tricky questions I don't have answers for yet, so I didn't want to add too much without getting a second opinion first.

## Fix caching of listens

Previously, cached listens were stored in a Dictionary with the Bluejay instance UUID as their keys. This is wrong because a Bluejay instance can be re-instantiated with a new and different UUID either by the user or by iOS during state restoration.

The fix uses the restore identifier as the keys in the Dictionary. The restore identifier is something that should remain constant and persist over not only different Bluejay instances, but the context of where and how Bluejay is used in the app as well.

## Improve adding and removing listen from cache

There is only a need to add a listen to the cache when `listen` is called, or remove a listen from the cache when `endListen` is called, if background mode with listen restoration is enabled.

## Replace `cancelAllOperations` with `cancelAllListens`

This function was outdated and no longer used anywhere in Bluejay after some iterations to the queuing system, which simplified and unified the interactions between the peripheral and the queue a little bit.

Before deleting this function, I took a quick look at it and it seemed like what it was meant for is to either cancel or error all the added listen callbacks. I figured there's some use for this, so I've changed the function name to `cancelAllListens`

One important note is that this function doesn't go through what `endListen` would go through, and only removes the listen callbacks at the end. It doesn't completely stop the listen. If the peripheral is still connected, we're actually still getting callbacks on `peripheral(_:didUpdateValueFor:error:)`, but they are just not being handled by Bluejay.

This could potentially have serious impact in performance for an app that subscribes to many characteristics. However, requiring this API to go through `endListen` has a few issues we need to work out:

1. It could be cancelled or fail half-way through, and that's quite annoying for both the framework and the user to handle and to recover. (e.g. losing connection to a peripheral or crashing in the middle of this)
  - If this happens, some cached listens are removed, some are still lingering
2. What if the user just wants to cancel and stop all listening, but keep the cached listens intact? Maybe I'm thinking too hard, and this isn't a useful case to support at all.

## Add `clearListenCaches` to the Bluejay API

Currently, the only way to remove a cached listen for state restoration is to use the `endListen` call. But that requires the peripheral being connected, and it also requires that call to reach the completion block. I think there are some edge cases that can happen preventing an `endListen` to finish in the queue – such as if the encapsulated DiscoveryService or DiscoveryCharacteristic operation hangs due to some Bluetooth issues, as we don't have timeouts for those yet.

I am not sure how useful this feature is, but I find it slightly dangerous not having a way to clear the listen cache if the device is disconnected, and if the app must operate with listen restoration enabled.

## Various small fixes to the heart sensor demo

- Do not try to end listen after being disconnected (this causes a bug that needs a new issue and PR)
- Add ability to test `cancelAllListens`, `startMonitoring`, `stopMonitoring`, and `cancelEverything` in the heart sensor demo
- And a few small fixes not worth mentioning