### PR TITLE
Make cbPeripheral public getter for Peripheral

### DIFF
--- a/Bluejay/Bluejay/Connection.swift
+++ b/Bluejay/Bluejay/Connection.swift
@@ -86,13 +86,23 @@ class Connection: Queueable {
     }
     
     func success(_ peripheral: CBPeripheral) {
+        guard let queue = queue else {
+            fail(BluejayError.missingQueue)
+            return
+        }
+        
+        guard let bluejay = queue.bluejay else {
+            fail(BluejayError.missingBluejay)
+            return
+        }
+        
         cancelTimer()
         
         state = .completed
         
         log("Connected to: \(peripheral.name ?? peripheral.identifier.uuidString).")
         
-        callback?(.success(peripheral))
+        callback?(.success(Peripheral(bluejay: bluejay, cbPeripheral: peripheral)))
         callback = nil
         
         updateQueue()

--- a/Bluejay/Bluejay/ConnectionResult.swift
+++ b/Bluejay/Bluejay/ConnectionResult.swift
@@ -7,12 +7,11 @@
 //
 
 import Foundation
-import CoreBluetooth
 
 /// Indicates a successful, cancelled, or failed connection attempt, where the success case contains the peripheral connected to.
 public enum ConnectionResult {
     /// The connection is successful, and the peripheral connected is captured in the associated value.
-    case success(CBPeripheral)
+    case success(Peripheral)
     /// The connection is cancelled for a reason.
     case cancelled
     /// The connection has failed unexpectedly with an error.

--- a/Bluejay/Bluejay/Disconnection.swift
+++ b/Bluejay/Bluejay/Disconnection.swift
@@ -53,9 +53,19 @@ class Disconnection: Queueable {
     }
     
     func success(_ peripheral: CBPeripheral) {
+        guard let queue = queue else {
+            fail(BluejayError.missingQueue)
+            return
+        }
+        
+        guard let bluejay = queue.bluejay else {
+            fail(BluejayError.missingBluejay)
+            return
+        }
+        
         state = .completed
                 
-        callback?(.success(peripheral))
+        callback?(.success(Peripheral(bluejay: bluejay, cbPeripheral: peripheral)))
         callback = nil
         
         updateQueue()

--- a/Bluejay/Bluejay/DisconnectionResult.swift
+++ b/Bluejay/Bluejay/DisconnectionResult.swift
@@ -7,12 +7,11 @@
 //
 
 import Foundation
-import CoreBluetooth
 
 /// Indicates a successful, cancelled, or failed disconnection attempt, where the success case contains the peripheral disconnected from.
 public enum DisconnectionResult {
     /// The disconnection is successful, and the disconnected peripheral is captured in the associated value.
-    case success(CBPeripheral)
+    case success(Peripheral)
     /// The disconnection is cancelled for a reason.
     case cancelled
     /// The disconnection has failed unexpectedly with an error.

--- a/Bluejay/Bluejay/Error.swift
+++ b/Bluejay/Bluejay/Error.swift
@@ -52,6 +52,10 @@ public enum BluejayError {
     case listenCacheEncoding(Error)
     /// Bluejay has failed to decode a listen cache.
     case listenCacheDecoding(Error)
+    /// Queue reference is missing.
+    case missingQueue
+    /// Bluejay reference is missing.
+    case missingBluejay
 }
 
 extension BluejayError: LocalizedError {
@@ -99,6 +103,10 @@ extension BluejayError: LocalizedError {
             return "Listen cache encoding failed with error: \(error.localizedDescription)"
         case let .listenCacheDecoding(error):
             return "Listen cache decoding failed with error: \(error.localizedDescription)"
+        case .missingQueue:
+            return "Reference to queue is missing."
+        case .missingBluejay:
+            return "Reference to bluejay is missing."
         }
     }
 }
@@ -132,6 +140,8 @@ extension BluejayError: CustomNSError {
         case .multipleBackgroundTaskNotSupported: return 19
         case .listenCacheEncoding: return 20
         case .listenCacheDecoding: return 21
+        case .missingQueue: return 22
+        case .missingBluejay: return 23
         }
     }
 

--- a/Bluejay/Bluejay/Peripheral.swift
+++ b/Bluejay/Bluejay/Peripheral.swift
@@ -17,7 +17,7 @@ public class Peripheral: NSObject {
     // MARK: Properties
     
     private(set) weak var bluejay: Bluejay?
-    private(set) var cbPeripheral: CBPeripheral
+    public private(set) var cbPeripheral: CBPeripheral
     
     fileprivate var listeners: [CharacteristicIdentifier : (ReadResult<Data?>) -> Void] = [:]
     fileprivate var listenersBeingCancelled: [CharacteristicIdentifier] = []

--- a/Bluejay/Bluejay/Peripheral.swift
+++ b/Bluejay/Bluejay/Peripheral.swift
@@ -17,7 +17,7 @@ public class Peripheral: NSObject {
     // MARK: Properties
     
     private(set) weak var bluejay: Bluejay?
-    public private(set) var cbPeripheral: CBPeripheral
+    private(set) var cbPeripheral: CBPeripheral
     
     fileprivate var listeners: [CharacteristicIdentifier : (ReadResult<Data?>) -> Void] = [:]
     fileprivate var listenersBeingCancelled: [CharacteristicIdentifier] = []
@@ -41,8 +41,8 @@ public class Peripheral: NSObject {
     
     // MARK: - Attributes
     
-    /// The UUID of the peripheral.
-    public var uuid: PeripheralIdentifier {
+    /// The identifier of the peripheral.
+    public var identifier: PeripheralIdentifier {
         return PeripheralIdentifier(uuid: cbPeripheral.identifier)
     }
     

--- a/Bluejay/Bluejay/Queue.swift
+++ b/Bluejay/Bluejay/Queue.swift
@@ -19,7 +19,7 @@ protocol QueueObserver: class {
 class Queue {
     
     /// Reference to the Bluejay that owns this queue.
-    private weak var bluejay: Bluejay?
+    public private(set) weak var bluejay: Bluejay?
     
     /// Helps determine whether a scan is running or not.
     private var scan: Scan?

--- a/Bluejay/BluejayDemo/HeartSensorViewController.swift
+++ b/Bluejay/BluejayDemo/HeartSensorViewController.swift
@@ -187,7 +187,7 @@ class HeartSensorViewController: UITableViewController {
         bluejay.connect(peripheralIdentifier) { (result) in
             switch result {
             case .success(let peripheral):
-                debugPrint("Connection to \(peripheral.identifier) successful.")
+                debugPrint("Connection to \(peripheral.identifier.uuid) successful.")
             case .cancelled:
                 debugPrint("Connection to \(peripheralIdentifier.uuid.uuidString) cancelled.")
             case .failure(let error):
@@ -210,7 +210,7 @@ class HeartSensorViewController: UITableViewController {
         bluejay.disconnect { (result) in
             switch result {
             case .success(let peripheral):
-                debugPrint("Disconnection from \(peripheral.identifier) successful.")
+                debugPrint("Disconnection from \(peripheral.identifier.uuid) successful.")
             case .cancelled:
                 debugPrint("Disconnection from \(peripheralIdentifier.uuid.uuidString) cancelled.")
             case .failure(let error):


### PR DESCRIPTION
The library has the inconsistency of how peripheral is used:
- `Bluejay.connect`, `Bluejay.disconnect` has callback with `CBPeripheral` result.
- `ConnectionObserver protocol` on did connect and did disconnect returns `Peripheral`.

So I propose making cbPeripheral getter public. Of course it may break some things, e.g. resetting delegate of CBPeripheral. But in other way it will add some flexibility when Bluejay doesn't have specific feature so that it can implemented bypassing Bluejay.

In my case I wrap CBPeripheral into my own class, but in case of using `ConnectionObserver` I'm unable doing it.