### PR TITLE
Update scan discovery and extend peripheral identifier

### DIFF
--- a/Bluejay/Bluejay/PeripheralIdentifier.swift
+++ b/Bluejay/Bluejay/PeripheralIdentifier.swift
@@ -18,5 +18,16 @@ public struct PeripheralIdentifier {
     public init(uuid: UUID) {
         self.uuid = uuid
     }
-    
+}
+
+extension PeripheralIdentifier: Equatable {
+    public static func == (lhs: PeripheralIdentifier, rhs: PeripheralIdentifier) -> Bool {
+        return lhs.uuid == rhs.uuid
+    }
+}
+
+extension PeripheralIdentifier: Hashable {
+    public var hashValue: Int {
+        return uuid.hashValue
+    }
 }

--- a/Bluejay/Bluejay/ScanDiscovery.swift
+++ b/Bluejay/Bluejay/ScanDiscovery.swift
@@ -12,9 +12,12 @@ import CoreBluetooth
 /// A model capturing what is found from a scan callback.
 public struct ScanDiscovery {
     
-    /// The `CBPeripheral` discovered.
-    public let peripheral: CBPeripheral
+    /// The unique, persistent identifier associated with the peer.
+    public let peripheralIdentifier: PeripheralIdentifier
     
+    /// The name of the peripheral.
+    public let peripheralName: String?
+
     /// The advertisement packet the discovered peripheral is sending.
     public let advertisementPacket: [String: Any]
     


### PR DESCRIPTION
The following are included in PR
1. ScanDiscovery shouldn't expose CBPeripheral, should expose a PeripheralIdentifier #113
2. PeripheralIdentifier (maybe others) should conform to Equatable and Hashable #114 

PS. This may be two separate PRs. But it's really easier and cleaner to implement #113 with #114 ready.