### PR TITLE
Code cleanup

### DIFF
--- a/Bluejay/Bluejay/Bluejay.swift
+++ b/Bluejay/Bluejay/Bluejay.swift
@@ -82,7 +82,7 @@ public class Bluejay: NSObject {
     /// Allows checking whether Bluejay is currently scanning.
     public var isScanning: Bool {
         // Cannot rely on the manager's state for isScanning as it is not usually updated immediately, and while that delay might be a more accurate representation of the current state, it is almost always more useful to evaluate whether Bluejay is running a scan request at the top of its queue.
-        return queue.isScanning()
+        return queue.isScanning
     }
     
     // MARK: - Initialization
@@ -887,7 +887,7 @@ extension Bluejay: CBCentralManagerDelegate {
             observer.weakReference?.disconnected(from: disconnectedPeripheral!)
         }
         
-        if !queue.isEmpty() {
+        if !queue.isEmpty {
             // If Bluejay is currently connecting or disconnecting, the queue needs to process this disconnection event. Otherwise, this is an unexpected disconnection.
             if isConnecting || isDisconnecting {
                 queue.process(event: .didDisconnectPeripheral(peripheral), error: error as NSError?)

--- a/Bluejay/Bluejay/Bluejay.swift
+++ b/Bluejay/Bluejay/Bluejay.swift
@@ -163,7 +163,7 @@ public class Bluejay: NSObject {
         
         cbCentralManager = CBCentralManager(
             delegate: self,
-            queue: DispatchQueue.main,
+            queue: .main,
             options: options
         )
     }
@@ -273,7 +273,7 @@ public class Bluejay: NSObject {
         if isRunningBackgroundTask {
             // Terminate the app if this is called from the same thread as the running background task.
             if #available(iOS 10.0, *) {
-                Dispatch.dispatchPrecondition(condition: .notOnQueue(DispatchQueue.global()))
+                Dispatch.dispatchPrecondition(condition: .notOnQueue(.global()))
             } else {
                 // Fallback on earlier versions
             }
@@ -299,7 +299,7 @@ public class Bluejay: NSObject {
         if isRunningBackgroundTask {
             // Terminate the app if this is called from the same thread as the running background task.
             if #available(iOS 10.0, *) {
-                Dispatch.dispatchPrecondition(condition: .notOnQueue(DispatchQueue.global()))
+                Dispatch.dispatchPrecondition(condition: .notOnQueue(.global()))
             } else {
                 // Fallback on earlier versions
             }
@@ -323,7 +323,7 @@ public class Bluejay: NSObject {
         if isRunningBackgroundTask {
             // Terminate the app if this is called from the same thread as the running background task.
             if #available(iOS 10.0, *) {
-                Dispatch.dispatchPrecondition(condition: .notOnQueue(DispatchQueue.global()))
+                Dispatch.dispatchPrecondition(condition: .notOnQueue(.global()))
             } else {
                 // Fallback on earlier versions
             }
@@ -355,7 +355,7 @@ public class Bluejay: NSObject {
         if isRunningBackgroundTask {
             // Terminate the app if this is called from the same thread as the running background task.
             if #available(iOS 10.0, *) {
-                Dispatch.dispatchPrecondition(condition: .notOnQueue(DispatchQueue.global()))
+                Dispatch.dispatchPrecondition(condition: .notOnQueue(.global()))
             } else {
                 // Fallback on earlier versions
             }
@@ -412,7 +412,7 @@ public class Bluejay: NSObject {
         if isRunningBackgroundTask {
             // Terminate the app if this is called from the same thread as the running background task.
             if #available(iOS 10.0, *) {
-                Dispatch.dispatchPrecondition(condition: .notOnQueue(DispatchQueue.global()))
+                Dispatch.dispatchPrecondition(condition: .notOnQueue(.global()))
             } else {
                 // Fallback on earlier versions
             }
@@ -440,7 +440,7 @@ public class Bluejay: NSObject {
         if isRunningBackgroundTask {
             // Terminate the app if this is called from the same thread as the running background task.
             if #available(iOS 10.0, *) {
-                Dispatch.dispatchPrecondition(condition: .notOnQueue(DispatchQueue.global()))
+                Dispatch.dispatchPrecondition(condition: .notOnQueue(.global()))
             } else {
                 // Fallback on earlier versions
             }
@@ -467,7 +467,7 @@ public class Bluejay: NSObject {
         if isRunningBackgroundTask {
             // Terminate the app if this is called from the same thread as the running background task.
             if #available(iOS 10.0, *) {
-                Dispatch.dispatchPrecondition(condition: .notOnQueue(DispatchQueue.global()))
+                Dispatch.dispatchPrecondition(condition: .notOnQueue(.global()))
             } else {
                 // Fallback on earlier versions
             }
@@ -494,7 +494,7 @@ public class Bluejay: NSObject {
         if isRunningBackgroundTask {
             // Terminate the app if this is called from the same thread as the running background task.
             if #available(iOS 10.0, *) {
-                Dispatch.dispatchPrecondition(condition: .notOnQueue(DispatchQueue.global()))
+                Dispatch.dispatchPrecondition(condition: .notOnQueue(.global()))
             } else {
                 // Fallback on earlier versions
             }
@@ -522,7 +522,7 @@ public class Bluejay: NSObject {
         if isRunningBackgroundTask {
             // Terminate the app if this is called from the same thread as the running background task.
             if #available(iOS 10.0, *) {
-                Dispatch.dispatchPrecondition(condition: .notOnQueue(DispatchQueue.global()))
+                Dispatch.dispatchPrecondition(condition: .notOnQueue(.global()))
             } else {
                 // Fallback on earlier versions
             }

--- a/Bluejay/Bluejay/Bluejay.swift
+++ b/Bluejay/Bluejay/Bluejay.swift
@@ -19,28 +19,28 @@ public class Bluejay: NSObject {
     // MARK: - Private Properties
     
     /// Internal reference to CoreBluetooth's CBCentralManager.
-    fileprivate var cbCentralManager: CBCentralManager!
+    private var cbCentralManager: CBCentralManager!
     
     /// List of weak references to objects interested in receiving notifications on Bluetooth connection events and state changes.
-    fileprivate var observers = [WeakConnectionObserver]()
+    private var observers = [WeakConnectionObserver]()
     
     /// Reference to a peripheral that is still connecting. If this is nil, then the peripheral should either be disconnected or connected. This is used to help determine the state of the peripheral's connection.
-    fileprivate var connectingPeripheral: Peripheral?
+    private var connectingPeripheral: Peripheral?
     
     /// Reference to a peripheral that is connected. If this is nil, then the peripheral should either be disconnected or still connecting. This is used to help determine the state of the peripheral's connection.
-    fileprivate var connectedPeripheral: Peripheral?
+    private var connectedPeripheral: Peripheral?
     
     /// Allowing or disallowing reconnection attempts upon a disconnection. It should only be set to true after a successful connection to a peripheral, and remain true unless there is an explicit and expected disconnection.
-    fileprivate var shouldAutoReconnect = false
+    private var shouldAutoReconnect = false
     
     /// Reference to the background task used for supporting state restoration.
-    fileprivate var startupBackgroundTask: UIBackgroundTaskIdentifier = UIBackgroundTaskInvalid
+    private var startupBackgroundTask: UIBackgroundTaskIdentifier = UIBackgroundTaskInvalid
     
     /// Reference to the peripheral identifier used for supporting state restoration.
-    fileprivate var peripheralIdentifierToRestore: PeripheralIdentifier?
+    private var peripheralIdentifierToRestore: PeripheralIdentifier?
     
     /// Determines whether state restoration is allowed.
-    fileprivate var shouldRestoreState = false
+    private var shouldRestoreState = false
     
     /// True when background task is running, and helps prevent calling regular read/write/listen.
     private var isRunningBackgroundTask = false

--- a/Bluejay/Bluejay/Bluejay.swift
+++ b/Bluejay/Bluejay/Bluejay.swift
@@ -684,13 +684,13 @@ public class Bluejay: NSObject {
      - Returns: The resulting data of all the Sendables combined in the order of the passed in array.
      */
     public static func combine(sendables: [Sendable]) -> Data {
-        let data = NSMutableData()
+        var data = Data()
         
         for sendable in sendables {
             data.append(sendable.toBluetoothData())
         }
         
-        return data as Data
+        return data
     }
     
 }

--- a/Bluejay/Bluejay/CBPeripheral+FindService.swift
+++ b/Bluejay/Bluejay/CBPeripheral+FindService.swift
@@ -13,7 +13,7 @@ extension CBPeripheral {
     
     /// Find a service on a peripheral by CBUUID.
     public func service(with uuid: CBUUID) -> CBService? {
-        return services?.filter { $0.uuid == uuid }.first
+        return services?.first(where: { $0.uuid == uuid })
     }
     
 }

--- a/Bluejay/Bluejay/CBService+FindCharacteristic.swift
+++ b/Bluejay/Bluejay/CBService+FindCharacteristic.swift
@@ -13,7 +13,7 @@ extension CBService {
     
     /// Find a characteristic on a service by CBUUID.
     public func characteristic(with uuid: CBUUID) -> CBCharacteristic? {
-        return characteristics?.filter { $0.uuid == uuid }.first
+        return characteristics?.first(where: { $0.uuid == uuid })
     }
     
 }

--- a/Bluejay/Bluejay/Peripheral.swift
+++ b/Bluejay/Bluejay/Peripheral.swift
@@ -393,7 +393,7 @@ extension Peripheral: CBPeripheralDelegate {
                 return characteristicIdentifier.uuid.uuidString == characteristic.uuid.uuidString
             })
             
-            let isReadUnhandled = isCancellingListenOnCurrentRead || (listeners.isEmpty && bluejay.queue.isEmpty())
+            let isReadUnhandled = isCancellingListenOnCurrentRead || (listeners.isEmpty && bluejay.queue.isEmpty)
             
             if isReadUnhandled {
                 return

--- a/Bluejay/Bluejay/Peripheral.swift
+++ b/Bluejay/Bluejay/Peripheral.swift
@@ -19,10 +19,10 @@ public class Peripheral: NSObject {
     private(set) weak var bluejay: Bluejay?
     private(set) var cbPeripheral: CBPeripheral
     
-    fileprivate var listeners: [CharacteristicIdentifier : (ReadResult<Data?>) -> Void] = [:]
-    fileprivate var listenersBeingCancelled: [CharacteristicIdentifier] = []
+    private var listeners: [CharacteristicIdentifier : (ReadResult<Data?>) -> Void] = [:]
+    private var listenersBeingCancelled: [CharacteristicIdentifier] = []
     
-    fileprivate var observers: [WeakRSSIObserver] = []
+    private var observers: [WeakRSSIObserver] = []
     
     // MARK: - Initialization
     
@@ -104,7 +104,7 @@ public class Peripheral: NSObject {
     
     // MARK: - Bluetooth Event
     
-    fileprivate func handleEvent(_ event: Event, error: NSError?) {
+    private func handleEvent(_ event: Event, error: NSError?) {
         guard let bluejay = bluejay else {
             preconditionFailure("Cannot handle event: Bluejay is nil.")
         }

--- a/Bluejay/Bluejay/Queue.swift
+++ b/Bluejay/Bluejay/Queue.swift
@@ -93,7 +93,7 @@ class Queue {
             }
             
             // Stop scanning when a connection is enqueued while a scan is still active, so that the queue can pop the scan task and proceed to the connection task without requiring the caller to explicitly stop the scan before making the connection request.
-            if isScanning() {
+            if isScanning {
                 stopScanning()
                 return
             }
@@ -185,7 +185,7 @@ class Queue {
     }
     
     func process(event: Event, error: Error?) {
-        if isEmpty() {
+        if isEmpty {
             log("Queue is empty but received an event: \(event)")
             return
         }
@@ -203,11 +203,11 @@ class Queue {
     
     // MARK: - States
     
-    func isEmpty() -> Bool {
+    var isEmpty: Bool {
         return queue.isEmpty
     }
     
-    func isScanning() -> Bool {
+    var isScanning: Bool {
         return scan != nil
     }
     
@@ -220,7 +220,7 @@ extension Queue: ConnectionObserver {
             update()
         }
         else {
-            if !isEmpty() {
+            if !isEmpty {
                 cancelAll(BluejayError.bluetoothUnavailable)
             }
         }

--- a/Bluejay/Bluejay/Scan.swift
+++ b/Bluejay/Bluejay/Scan.swift
@@ -80,7 +80,7 @@ class Scan: Queueable {
             NotificationCenter.default.addObserver(
                 self,
                 selector: #selector(didEnterBackgroundWithAllowDuplicates),
-                name: NSNotification.Name.UIApplicationDidEnterBackground,
+                name: .UIApplicationDidEnterBackground,
                 object: nil
             )
         }
@@ -89,7 +89,7 @@ class Scan: Queueable {
             NotificationCenter.default.addObserver(
                 self,
                 selector: #selector(didEnterBackgroundWithoutServiceIdentifiers),
-                name: NSNotification.Name.UIApplicationDidEnterBackground,
+                name: .UIApplicationDidEnterBackground,
                 object: nil
             )
         }

--- a/Bluejay/Bluejay/Scan.swift
+++ b/Bluejay/Bluejay/Scan.swift
@@ -9,9 +9,6 @@
 import Foundation
 import CoreBluetooth
 
-private let deviceInfoService = ServiceIdentifier(uuid: "180A")
-private let serialNumberCharacteristic = CharacteristicIdentifier(uuid: "2A25", service: deviceInfoService)
-
 /// A scan operation.
 class Scan: Queueable {
     

--- a/Bluejay/Bluejay/SynchronizedPeripheral.swift
+++ b/Bluejay/Bluejay/SynchronizedPeripheral.swift
@@ -141,7 +141,7 @@ public class SynchronizedPeripheral {
             }
         }
         
-        _ = sem.wait(timeout: DispatchTime.distantFuture)
+        _ = sem.wait(timeout: .distantFuture)
 
         if let errorToThrow = errorToThrow {
             throw errorToThrow
@@ -189,7 +189,7 @@ public class SynchronizedPeripheral {
                 })
             }
             
-            _ = flushSem.wait(timeout: DispatchTime.now() + .seconds(idleWindow))
+            _ = flushSem.wait(timeout: .now() + .seconds(idleWindow))
             
             DispatchQueue.main.async {
                 if self.parent.isListening(to: characteristicIdentifier) {
@@ -208,7 +208,7 @@ public class SynchronizedPeripheral {
                 }
             }
             
-            _ = cleanUpSem.wait(timeout: DispatchTime.distantFuture)
+            _ = cleanUpSem.wait(timeout: .distantFuture)
             
             DispatchQueue.main.async {
                 log("Flush to \(characteristicIdentifier.uuid.uuidString) finished, should flush again: \(shouldListenAgain).")
@@ -219,7 +219,7 @@ public class SynchronizedPeripheral {
             }
         } while shouldListenAgain
         
-        _ = sem.wait(timeout: DispatchTime.distantFuture)
+        _ = sem.wait(timeout: .distantFuture)
         
         if let error = error {
             throw error
@@ -249,7 +249,7 @@ public class SynchronizedPeripheral {
         DispatchQueue.main.sync {
             self.parent.listen(to: charToListenTo, completion: { (result : ReadResult<R>) in
                 listenResult = result
-                var action = ListenAction.done
+                var action: ListenAction = .done
                 
                 switch result {
                 case .success(let r):
@@ -281,7 +281,7 @@ public class SynchronizedPeripheral {
             
         }
         
-        _ = sem.wait(timeout: timeoutInSeconds == 0 ? DispatchTime.distantFuture : DispatchTime.now() + .seconds(timeoutInSeconds))
+        _ = sem.wait(timeout: timeoutInSeconds == 0 ? .distantFuture : .now() + .seconds(timeoutInSeconds))
         
         if let error = error {
             throw error
@@ -368,7 +368,7 @@ public class SynchronizedPeripheral {
             }
         }
         
-        _ = sem.wait(timeout: timeoutInSeconds == 0 ? DispatchTime.distantFuture : DispatchTime.now() + .seconds(timeoutInSeconds))
+        _ = sem.wait(timeout: timeoutInSeconds == 0 ? .distantFuture : .now() + .seconds(timeoutInSeconds))
         
         if self.parent.isListening(to: charToListenTo) {
             // TODO: Handle end listen failures.

--- a/Bluejay/BluejayDemo/HeartSensorViewController.swift
+++ b/Bluejay/BluejayDemo/HeartSensorViewController.swift
@@ -24,10 +24,10 @@ class HeartSensorViewController: UITableViewController {
     @IBOutlet var resetCell: UITableViewCell!
     @IBOutlet var cancelEverythingCell: UITableViewCell!
     
-    fileprivate var isMonitoringHeartRate = false
+    private var isMonitoringHeartRate = false
     
     private var shouldRefreshSensorLocation = false
-    fileprivate var sensorLocation: UInt8?
+    private var sensorLocation: UInt8?
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -53,7 +53,7 @@ class HeartSensorViewController: UITableViewController {
         }
     }
     
-    fileprivate func showBluejayMissingAlert() {
+    private func showBluejayMissingAlert() {
         let alert = UIAlertController(title: "Bluejay Error", message: "Bluejay is missing.", preferredStyle: .alert)
         let dismiss = UIAlertAction(title: "Dismiss", style: .default, handler: nil)
         
@@ -62,7 +62,7 @@ class HeartSensorViewController: UITableViewController {
         navigationController?.present(alert, animated: true, completion: nil)
     }
     
-    fileprivate func readSensorLocation() {
+    private func readSensorLocation() {
         guard let bluejay = bluejay else {
             showBluejayMissingAlert()
             return
@@ -116,7 +116,7 @@ class HeartSensorViewController: UITableViewController {
         sensorLocation = value
     }
     
-    fileprivate func startMonitoringHeartRate() {
+    private func startMonitoringHeartRate() {
         if isMonitoringHeartRate {
             return
         }
@@ -161,7 +161,7 @@ class HeartSensorViewController: UITableViewController {
         }
     }
     
-    fileprivate func stopMonitoringHeartRate() {
+    private func stopMonitoringHeartRate() {
         guard let bluejay = bluejay else {
             showBluejayMissingAlert()
             return

--- a/Bluejay/BluejayDemo/ScanEverythingViewController.swift
+++ b/Bluejay/BluejayDemo/ScanEverythingViewController.swift
@@ -11,7 +11,7 @@ import Bluejay
 
 class ScanEverythingViewController: UITableViewController {
     
-    fileprivate let bluejay = Bluejay()
+    private let bluejay = Bluejay()
     
     private var peripherals = [ScanDiscovery]() {
         didSet {
@@ -29,7 +29,7 @@ class ScanEverythingViewController: UITableViewController {
         startScanning()
     }
     
-    fileprivate func startScanning() {
+    private func startScanning() {
         bluejay.scan(
             allowDuplicates: true,
             serviceIdentifiers: nil,

--- a/Bluejay/BluejayDemo/ScanHeartRateSensorsViewController.swift
+++ b/Bluejay/BluejayDemo/ScanHeartRateSensorsViewController.swift
@@ -11,7 +11,7 @@ import Bluejay
 
 class ScanHeartRateSensorsViewController: UITableViewController {
     
-    fileprivate let bluejay = Bluejay()
+    private let bluejay = Bluejay()
     
     private var peripherals = [ScanDiscovery]() {
         didSet {
@@ -33,7 +33,7 @@ class ScanHeartRateSensorsViewController: UITableViewController {
         scanHeartSensors()
     }
     
-    fileprivate func scanHeartSensors() {
+    private func scanHeartSensors() {
         let heartRateService = ServiceIdentifier(uuid: "180D")
         
         bluejay.scan(


### PR DESCRIPTION
* use `first(where:_)` instead of `filter` and then `first`
* remove redundant declarations from `Scan.swift`
* replace `fileprivate` with `private` since it's redundant in Swift 4
* use `Data` instead of `NSData`
* use `.` initialisation syntax when it's possible