### PR TITLE
Fix disconnect cleanup for bg task

### DIFF
--- a/Bluejay.podspec
+++ b/Bluejay.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |spec|
   spec.name = 'Bluejay'
-  spec.version = '0.4.1'
+  spec.version = '0.4.2'
   spec.license = { type: 'MIT', file: 'LICENSE' }
   spec.homepage = 'https://github.com/steamclock/bluejay'
   spec.authors = { 'Jeremy Chiang' => 'jeremy@steamclock.com' }
   spec.summary = 'Bluejay is a simple Swift framework for building reliable Bluetooth apps.'
   spec.homepage = 'https://github.com/steamclock/bluejay'
-  spec.source = { git: 'https://github.com/steamclock/bluejay.git', tag: 'v0.4.1' }
+  spec.source = { git: 'https://github.com/steamclock/bluejay.git', tag: 'v0.4.2' }
   spec.source_files = 'Bluejay/Bluejay/*.{h,swift}'
   spec.framework = 'SystemConfiguration'
   spec.platform = :ios, '9.3'

--- a/Bluejay/Bluejay/Bluejay.swift
+++ b/Bluejay/Bluejay/Bluejay.swift
@@ -594,6 +594,7 @@ public class Bluejay: NSObject {
                         
                         if error == BluejayError.notConnected as NSError {
                             weakSelf.disconnectCleanUp?()
+                            weakSelf.disconnectCleanUp = nil
                         }
                     }
                 }
@@ -651,6 +652,7 @@ public class Bluejay: NSObject {
                         
                         if error == BluejayError.notConnected as NSError {
                             weakSelf.disconnectCleanUp?()
+                            weakSelf.disconnectCleanUp = nil
                         }
                     }
                 }
@@ -710,6 +712,7 @@ public class Bluejay: NSObject {
                         
                         if error == BluejayError.notConnected as NSError {
                             weakSelf.disconnectCleanUp?()
+                            weakSelf.disconnectCleanUp = nil
                         }
                     }
                 }

--- a/Bluejay/Bluejay/Info.plist
+++ b/Bluejay/Bluejay/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.4.1</string>
+	<string>0.4.2</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>


### PR DESCRIPTION
- Transfer disconnect clean up responsibility to the background task if there is one

- Also fixes incorrect assumptions on what the states should be initially for auto reconnect, and when calling cancel everything - cancel everything is not the same as calling disconnect explicitly.

- Bump version to 0.4.2