### PR TITLE
Fix end listen for write and listen

### DIFF
--- a/Bluejay.podspec
+++ b/Bluejay.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |spec|
   spec.name = 'Bluejay'
-  spec.version = '0.4.2'
+  spec.version = '0.4.3'
   spec.license = { type: 'MIT', file: 'LICENSE' }
   spec.homepage = 'https://github.com/steamclock/bluejay'
   spec.authors = { 'Jeremy Chiang' => 'jeremy@steamclock.com' }
   spec.summary = 'Bluejay is a simple Swift framework for building reliable Bluetooth apps.'
   spec.homepage = 'https://github.com/steamclock/bluejay'
-  spec.source = { git: 'https://github.com/steamclock/bluejay.git', tag: 'v0.4.2' }
+  spec.source = { git: 'https://github.com/steamclock/bluejay.git', tag: 'v0.4.3' }
   spec.source_files = 'Bluejay/Bluejay/*.{h,swift}'
   spec.framework = 'SystemConfiguration'
   spec.platform = :ios, '9.3'

--- a/Bluejay/Bluejay/Error.swift
+++ b/Bluejay/Bluejay/Error.swift
@@ -52,6 +52,8 @@ public enum BluejayError {
     case listenCacheEncoding(Error)
     /// Bluejay has failed to decode a listen cache.
     case listenCacheDecoding(Error)
+    /// Bluejay has cancelled an expected end listen request.
+    case endListenCancelled
 }
 
 extension BluejayError: LocalizedError {
@@ -99,6 +101,8 @@ extension BluejayError: LocalizedError {
             return "Listen cache encoding failed with error: \(error.localizedDescription)"
         case let .listenCacheDecoding(error):
             return "Listen cache decoding failed with error: \(error.localizedDescription)"
+        case let .endListenCancelled:
+            return "End listen cancelled."
         }
     }
 }
@@ -132,6 +136,7 @@ extension BluejayError: CustomNSError {
         case .multipleBackgroundTaskNotSupported: return 19
         case .listenCacheEncoding: return 20
         case .listenCacheDecoding: return 21
+        case .endListenCancelled: return 22
         }
     }
 

--- a/Bluejay/Bluejay/Info.plist
+++ b/Bluejay/Bluejay/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.4.2</string>
+	<string>0.4.3</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>


### PR DESCRIPTION
If a disconnect occurs during an end listen call in a write and listen operation, we need the end listen call to propagate that disconnection error back to the background task to allow it to catch and throw the disconnect error back to the background task's completion block.