### PR TITLE
Fix write and assemble

### DIFF
--- a/Bluejay.podspec
+++ b/Bluejay.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |spec|
   spec.name = 'Bluejay'
-  spec.version = '0.4.4'
+  spec.version = '0.4.5'
   spec.license = { type: 'MIT', file: 'LICENSE' }
   spec.homepage = 'https://github.com/steamclock/bluejay'
   spec.authors = { 'Jeremy Chiang' => 'jeremy@steamclock.com' }
   spec.summary = 'Bluejay is a simple Swift framework for building reliable Bluetooth apps.'
   spec.homepage = 'https://github.com/steamclock/bluejay'
-  spec.source = { git: 'https://github.com/steamclock/bluejay.git', tag: 'v0.4.4' }
+  spec.source = { git: 'https://github.com/steamclock/bluejay.git', tag: 'v0.4.5' }
   spec.source_files = 'Bluejay/Bluejay/*.{h,swift}'
   spec.framework = 'SystemConfiguration'
   spec.platform = :ios, '9.3'

--- a/Bluejay/Bluejay/Info.plist
+++ b/Bluejay/Bluejay/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.4.4</string>
+	<string>0.4.5</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>


### PR DESCRIPTION
Apply the same recent fixes made to `writeAndListen` for `writeAndAssemble` as well:

- Better management of semaphore locks and releases
- Better usage of end listen
- Allow failing the operation if bluetooth becomes unavailable or if there's a disconnection after both the read and listen have been setup correctly