### PR TITLE
[v0.4.8] Add timeout to synchronized listen

### DIFF
--- a/Bluejay.podspec
+++ b/Bluejay.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |spec|
   spec.name = 'Bluejay'
-  spec.version = '0.4.6'
+  spec.version = '0.4.8'
   spec.license = { type: 'MIT', file: 'LICENSE' }
   spec.homepage = 'https://github.com/steamclock/bluejay'
   spec.authors = { 'Jeremy Chiang' => 'jeremy@steamclock.com' }
   spec.summary = 'Bluejay is a simple Swift framework for building reliable Bluetooth apps.'
   spec.homepage = 'https://github.com/steamclock/bluejay'
-  spec.source = { git: 'https://github.com/steamclock/bluejay.git', tag: 'v0.4.6' }
+  spec.source = { git: 'https://github.com/steamclock/bluejay.git', tag: 'v0.4.8' }
   spec.source_files = 'Bluejay/Bluejay/*.{h,swift}'
   spec.framework = 'SystemConfiguration'
   spec.platform = :ios, '9.3'

--- a/Bluejay/Bluejay/Info.plist
+++ b/Bluejay/Bluejay/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.4.6</string>
+	<string>0.4.8</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Bluejay/Bluejay/SynchronizedPeripheral.swift
+++ b/Bluejay/Bluejay/SynchronizedPeripheral.swift
@@ -90,23 +90,35 @@ public class SynchronizedPeripheral {
     }
     
     /// Listen for changes on a specified characterstic synchronously.
-    public func listen<R: Receivable>(to characteristicIdentifier: CharacteristicIdentifier, completion: @escaping (R) -> ListenAction) throws {
+    public func listen<R: Receivable>(
+        to characteristicIdentifier: CharacteristicIdentifier,
+        timeoutInSeconds: Int = 0,
+        completion: @escaping (R) -> ListenAction) throws
+    {
         let sem = DispatchSemaphore(value: 0)
+        
+        var listenResult: ReadResult<R>?
         var error : Error?
+        
+        backupTermination = { bluejayError in
+            error = bluejayError
+            sem.signal()
+        }
         
         DispatchQueue.main.async {
             self.parent.listen(to: characteristicIdentifier, completion: { (result : ReadResult<R>) in
+                listenResult = result
                 var action = ListenAction.done
                 
                 switch result {
                 case .success(let r):
                     action = completion(r)
                 case .cancelled:
-                    sem.signal()
+                    error = BluejayError.cancelled
                 case .failure(let e):
                     error = e
                 }
-                                
+                
                 if error != nil || action == .done {
                     if self.parent.isListening(to: characteristicIdentifier) && self.bluetoothAvailable {
                         self.parent.endListen(to: characteristicIdentifier, error: nil, completion: { (result) in
@@ -134,10 +146,20 @@ public class SynchronizedPeripheral {
             })
         }
         
-        _ = sem.wait(timeout: DispatchTime.distantFuture)
+        _ = sem.wait(timeout: timeoutInSeconds == 0 ? .distantFuture : .now() + .seconds(timeoutInSeconds))
         
         if let error = error {
+            backupTermination = nil
             throw error
+        }
+        else if listenResult == nil {
+            backupTermination = nil
+            
+            if self.parent.isListening(to: characteristicIdentifier) && self.bluetoothAvailable {
+                self.parent.endListen(to: characteristicIdentifier)
+            }
+            
+            throw BluejayError.listenTimedOut
         }
     }
     

--- a/Bluejay/Bluejay/SynchronizedPeripheral.swift
+++ b/Bluejay/Bluejay/SynchronizedPeripheral.swift
@@ -92,7 +92,7 @@ public class SynchronizedPeripheral {
     /// Listen for changes on a specified characterstic synchronously.
     public func listen<R: Receivable>(
         to characteristicIdentifier: CharacteristicIdentifier,
-        timeout: Timeout,
+        timeout: Timeout = .none,
         completion: @escaping (R) -> ListenAction) throws
     {
         let sem = DispatchSemaphore(value: 0)

--- a/Bluejay/Bluejay/SynchronizedPeripheral.swift
+++ b/Bluejay/Bluejay/SynchronizedPeripheral.swift
@@ -92,7 +92,7 @@ public class SynchronizedPeripheral {
     /// Listen for changes on a specified characterstic synchronously.
     public func listen<R: Receivable>(
         to characteristicIdentifier: CharacteristicIdentifier,
-        timeoutInSeconds: Int = 0,
+        timeout: Timeout,
         completion: @escaping (R) -> ListenAction) throws
     {
         let sem = DispatchSemaphore(value: 0)
@@ -146,7 +146,11 @@ public class SynchronizedPeripheral {
             })
         }
         
-        _ = sem.wait(timeout: timeoutInSeconds == 0 ? .distantFuture : .now() + .seconds(timeoutInSeconds))
+        if case let .seconds(timeoutInterval) = timeout {
+            _ = sem.wait(timeout: .now() + DispatchTimeInterval.seconds(Int(timeoutInterval)))
+        } else {
+            _ = sem.wait(timeout: .distantFuture)
+        }
         
         if let error = error {
             backupTermination = nil


### PR DESCRIPTION
Helps prevent the run background task from getting stuck if a listen never gets any updates.