### PR TITLE
[v0.5.0] Fix incorrect connection cancellation

### DIFF
--- a/Bluejay.podspec
+++ b/Bluejay.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |spec|
   spec.name = 'Bluejay'
-  spec.version = '0.4.8'
+  spec.version = '0.5.0'
   spec.license = { type: 'MIT', file: 'LICENSE' }
   spec.homepage = 'https://github.com/steamclock/bluejay'
   spec.authors = { 'Jeremy Chiang' => 'jeremy@steamclock.com' }
   spec.summary = 'Bluejay is a simple Swift framework for building reliable Bluetooth apps.'
   spec.homepage = 'https://github.com/steamclock/bluejay'
-  spec.source = { git: 'https://github.com/steamclock/bluejay.git', tag: 'v0.4.8' }
+  spec.source = { git: 'https://github.com/steamclock/bluejay.git', tag: 'v0.5.0' }
   spec.source_files = 'Bluejay/Bluejay/*.{h,swift}'
   spec.framework = 'SystemConfiguration'
   spec.platform = :ios, '9.3'

--- a/Bluejay/Bluejay/Connection.swift
+++ b/Bluejay/Bluejay/Connection.swift
@@ -138,11 +138,7 @@ class Connection: Queueable {
         
         // There is no point trying to cancel the connection if the error is due to the manager being powered off, as trying to do so has no effect and will also cause CoreBluetooth to log an "API MISUSE" warning.
         if manager.state == .poweredOn {
-            // Don't cancel the existing connection if the error is caused by mistakingly adding another connection request while Bluejay is still connecting or connected.
-            if case BluejayError.multipleConnectNotSupported = error {
-                manager.cancelPeripheralConnection(peripheral)
-            }
-            else if case BluejayError.connectionTimedOut = error {
+            if case BluejayError.connectionTimedOut = error {
                 manager.cancelPeripheralConnection(peripheral)
             }
             else {

--- a/Bluejay/Bluejay/Info.plist
+++ b/Bluejay/Bluejay/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.4.8</string>
+	<string>0.5.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>


### PR DESCRIPTION
For #145

Rob has helped us discovered a bug where the second connection request can mistakingly cancel the first and still ongoing connection request, resulting in the second connection request not getting a callback.