### PR TITLE
[v0.5.1] Fix accessing of the listen cache

### DIFF
--- a/Bluejay.podspec
+++ b/Bluejay.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |spec|
   spec.name = 'Bluejay'
-  spec.version = '0.4.8'
+  spec.version = '0.5.1'
   spec.license = { type: 'MIT', file: 'LICENSE' }
   spec.homepage = 'https://github.com/steamclock/bluejay'
   spec.authors = { 'Jeremy Chiang' => 'jeremy@steamclock.com' }
   spec.summary = 'Bluejay is a simple Swift framework for building reliable Bluetooth apps.'
   spec.homepage = 'https://github.com/steamclock/bluejay'
-  spec.source = { git: 'https://github.com/steamclock/bluejay.git', tag: 'v0.4.8' }
+  spec.source = { git: 'https://github.com/steamclock/bluejay.git', tag: 'v0.5.1' }
   spec.source_files = 'Bluejay/Bluejay/*.{h,swift}'
   spec.framework = 'SystemConfiguration'
   spec.platform = :ios, '9.3'

--- a/Bluejay/Bluejay/Bluejay.swift
+++ b/Bluejay/Bluejay/Bluejay.swift
@@ -809,7 +809,8 @@ extension Bluejay: CBCentralManagerDelegate {
         
         guard
             let listenCaches = UserDefaults.standard.dictionary(forKey: Constant.listenCaches),
-            let cacheData = listenCaches[uuid.uuidString] as? [Data]
+            let restoreIdentifier = restoreIdentifier,
+            let cacheData = listenCaches[restoreIdentifier] as? [Data]
         else {
             log("No listens to restore.")
             return

--- a/Bluejay/Bluejay/Info.plist
+++ b/Bluejay/Bluejay/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.4.8</string>
+	<string>0.5.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>


### PR DESCRIPTION
Thank you to @shekhar-suman who discovered this issue.

Previously the listeners were cached using the Bluejay instance uuid, but we've since switched to using the restore identifier, and the accessing of the listen cache wasn't updated.