### PR TITLE
Is listening to characteristic method on connected peripheral

### DIFF
--- a/Bluejay/Bluejay/Bluejay.swift
+++ b/Bluejay/Bluejay/Bluejay.swift
@@ -588,6 +588,20 @@ public class Bluejay: NSObject {
         }
     }
     
+    /**
+     Check if a peripheral is listening to a specific characteristic.
+     
+     - Parameters:
+     - characteristicIdentifier: The characteristic we want to know check.
+     - Returns: a boolean value
+     */
+    public func isListening(to characteristicIdentifier: CharacteristicIdentifier) -> Bool? {
+        guard let periph = connectedPeripheral else {
+            return nil
+        }
+        return periph.isListening(to: characteristicIdentifier)
+    }
+    
     // MARK: - Background Task
     
     /**

--- a/Bluejay/Bluejay/Bluejay.swift
+++ b/Bluejay/Bluejay/Bluejay.swift
@@ -592,7 +592,7 @@ public class Bluejay: NSObject {
      Check if a peripheral is listening to a specific characteristic.
      
      - Parameters:
-     - characteristicIdentifier: The characteristic we want to know check.
+     - characteristicIdentifier: The characteristic we want to check.
      - Returns: a boolean value
      */
     public func isListening(to characteristicIdentifier: CharacteristicIdentifier) -> Bool? {

--- a/Bluejay/Bluejay/Bluejay.swift
+++ b/Bluejay/Bluejay/Bluejay.swift
@@ -595,9 +595,9 @@ public class Bluejay: NSObject {
      - characteristicIdentifier: The characteristic we want to check.
      - Returns: a boolean value
      */
-    public func isListening(to characteristicIdentifier: CharacteristicIdentifier) -> Bool? {
+    public func isListening(to characteristicIdentifier: CharacteristicIdentifier) throws -> Bool {
         guard let periph = connectedPeripheral else {
-            return nil
+            throw BluejayError.notConnected
         }
         return periph.isListening(to: characteristicIdentifier)
     }


### PR DESCRIPTION
The `isListening` method is only available on a `Peripheral` instance, thus to understand if we are already listening to a specific characteristic the current process should be.

1. Create a `ConnectionObserver` object
2. In the `connected(to peripheral: Peripheral)` store the instance of the connected peripheral to a variable
3. When is needed ask the peripheral if someone is listening to a specific characteristic by using the `isListening` exposed from the `Peripheral` instance

This is due to the fact that from the `Bluejay` instance side the connected peripheral is not exposed.
I've added a method to the `Bluejay` class that basically asks the connected peripheral if it is listening for a specific characteristic, if no peripheral is connected it throws and error.
I'm wondering if you are interested in such feature.


