### PR TITLE
Add warnings to scan against leaving serviceIdentifiers set to `nil` or empty

### DIFF
--- a/Bluejay.podspec
+++ b/Bluejay.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |spec|
   spec.authors = { 'Jeremy Chiang' => 'jeremy@steamclock.com' }
   spec.summary = 'Bluejay is a simple Swift framework for building reliable Bluetooth apps.'
   spec.homepage = 'https://github.com/steamclock/bluejay'
-  spec.source = { git: 'https://github.com/steamclock/bluejay.git', tag: 'v0.6.3' }
+  spec.source = { git: 'https://github.com/steamclock/bluejay.git', tag: 'v0.6.4' }
   spec.source_files = 'Bluejay/Bluejay/*.{h,swift}'
   spec.framework = 'SystemConfiguration'
   spec.platform = :ios, '9.3'

--- a/Bluejay.podspec
+++ b/Bluejay.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name = 'Bluejay'
-  spec.version = '0.6.3'
+  spec.version = '0.6.4'
   spec.license = { type: 'MIT', file: 'LICENSE' }
   spec.homepage = 'https://github.com/steamclock/bluejay'
   spec.authors = { 'Jeremy Chiang' => 'jeremy@steamclock.com' }

--- a/Bluejay/Bluejay/Bluejay.swift
+++ b/Bluejay/Bluejay/Bluejay.swift
@@ -312,6 +312,8 @@ public class Bluejay: NSObject {
     
     /**
      Scan for the peripheral(s) specified.
+
+     - Warning: Setting `serviceIdentifiers` to `nil` will result in picking up all available Bluetooth peripherals in the vicinity, **but is not recommended by Apple**. It may cause battery and cpu issues on prolonged scanning, and **it also doesn't work in the background**. If you need to scan for all Bluetooth devices, we recommend making use of the `duration` parameter to stop the scan after 5 ~ 10 seconds to avoid scanning indefinitely and overloading the hardware.
      
      - Parameters:
         - duration: Stops the scan when the duration in seconds is reached. Defaults to zero (indefinite).

--- a/Bluejay/Bluejay/Info.plist
+++ b/Bluejay/Bluejay/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.6.3</string>
+	<string>0.6.4</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Bluejay/Bluejay/Scan.swift
+++ b/Bluejay/Bluejay/Scan.swift
@@ -68,6 +68,10 @@ class Scan: Queueable {
         self.expired = expired
         self.stopped = stopped
         self.manager = manager
+
+        if serviceIdentifiers?.isEmpty != false {
+            log("Warning: Setting `serviceIdentifiers` to `nil` is not recommended by Apple. It may cause battery and cpu issues on prolonged scanning, and **it also doesn't work in the background**. If you need to scan for all Bluetooth devices, we recommend making use of the `duration` parameter to stop the scan after 5 ~ 10 seconds to avoid scanning indefinitely and overloading the hardware.")
+        }
     }
         
     func start() {        

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.6.4] - 2018-08-02
+### Added
+- Added warnings against using `scan` with `serviceIdentifiers` set to `nil` or empty. 
+
 ## [0.6.3] - 2018-07-26
 ### Added
 - Add API to check whether a peripheral is listening to a characteristic


### PR DESCRIPTION
Added a console warning and warning to `Bluejay.scan` to discourage accidentally scanning with `serviceProviders` set to `nil` or empty. 

I accidentally ran into this on another project and there was some discussion of adding a warning like this to prevent it happening again.