### PR TITLE
Add option to change threshold for throttling discoveries by RSSI

### DIFF
--- a/Bluejay.podspec
+++ b/Bluejay.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |spec|
   spec.name = 'Bluejay'
-  spec.version = '0.6.4'
+  spec.version = '0.6.5'
   spec.license = { type: 'MIT', file: 'LICENSE' }
   spec.homepage = 'https://github.com/steamclock/bluejay'
   spec.authors = { 'Jeremy Chiang' => 'jeremy@steamclock.com' }
   spec.summary = 'Bluejay is a simple Swift framework for building reliable Bluetooth apps.'
   spec.homepage = 'https://github.com/steamclock/bluejay'
-  spec.source = { git: 'https://github.com/steamclock/bluejay.git', tag: 'v0.6.4' }
+  spec.source = { git: 'https://github.com/steamclock/bluejay.git', tag: 'v0.6.5' }
   spec.source_files = 'Bluejay/Bluejay/*.{h,swift}'
   spec.framework = 'SystemConfiguration'
   spec.platform = :ios, '9.3'

--- a/Bluejay/Bluejay/Bluejay.swift
+++ b/Bluejay/Bluejay/Bluejay.swift
@@ -318,6 +318,7 @@ public class Bluejay: NSObject {
      - Parameters:
         - duration: Stops the scan when the duration in seconds is reached. Defaults to zero (indefinite).
         - allowDuplicates: Determines whether a previously scanned peripheral is allowed to be discovered again.
+        - throttleRSSIDelta: Throttles discoveries by ignoring insignificant changes to RSSI.
         - serviceIdentifiers: Specifies what visible services the peripherals must have in order to be discovered.
         - discovery: Called whenever a specified peripheral has been discovered.
         - expired: Called whenever a previously discovered peripheral has not been seen again for a while, and Bluejay is predicting that it may no longer be in range. (Only for a scan with allowDuplicates enabled)
@@ -326,6 +327,7 @@ public class Bluejay: NSObject {
     public func scan(
         duration: TimeInterval = 0,
         allowDuplicates: Bool = false,
+        throttleRSSIDelta: Int = 5,
         serviceIdentifiers: [ServiceIdentifier]?,
         discovery: @escaping (ScanDiscovery, [ScanDiscovery]) -> ScanAction,
         expired: ((ScanDiscovery, [ScanDiscovery]) -> ScanAction)? = nil,
@@ -346,6 +348,7 @@ public class Bluejay: NSObject {
         let scanOperation = Scan(
             duration: duration,
             allowDuplicates: allowDuplicates,
+            throttleRSSIDelta: throttleRSSIDelta,
             serviceIdentifiers: serviceIdentifiers,
             discovery: discovery,
             expired: expired,

--- a/Bluejay/Bluejay/Info.plist
+++ b/Bluejay/Bluejay/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.6.4</string>
+	<string>0.6.5</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Bluejay/Bluejay/Scan.swift
+++ b/Bluejay/Bluejay/Scan.swift
@@ -29,7 +29,10 @@ class Scan: Queueable {
     
     /// If allowDuplicates is true, the scan will repeatedly discover the same device as long as its advertisement is picked up. This is a Core Bluetooth option, and it does consume more battery, doesn't work in the background, and is often advised to turn off.
     private let allowDuplicates: Bool
-    
+
+    /// Throttle discoveries by ignoring discovery if the change in RSSI is insignificant. 0 will never throttle discoveries, default is 5 dBm.
+    private let throttleRSSIDelta: Int
+
     /// The scan will only look for peripherals broadcasting the specified services.
     private let serviceIdentifiers: [ServiceIdentifier]?
     
@@ -53,6 +56,7 @@ class Scan: Queueable {
     
     init(duration: TimeInterval,
          allowDuplicates: Bool,
+         throttleRSSIDelta: Int,
          serviceIdentifiers: [ServiceIdentifier]?,
          discovery: @escaping (ScanDiscovery, [ScanDiscovery]) -> ScanAction,
          expired: ((ScanDiscovery, [ScanDiscovery]) -> ScanAction)?,
@@ -63,6 +67,7 @@ class Scan: Queueable {
         
         self.duration = duration
         self.allowDuplicates = allowDuplicates
+        self.throttleRSSIDelta = throttleRSSIDelta
         self.serviceIdentifiers = serviceIdentifiers
         self.discovery = discovery
         self.expired = expired
@@ -152,7 +157,7 @@ class Scan: Queueable {
                 let existingDiscovery = discoveries[indexOfExistingDiscovery]
                 
                 // Throttle discovery by ignoring discovery if the change of RSSI is insignificant.
-                if abs(existingDiscovery.rssi - rssi.intValue) < 5 {
+                if abs(existingDiscovery.rssi - rssi.intValue) < throttleRSSIDelta {
                     return
                 }
                 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Added an option to `scan` to change the threshold for ignoring discoveries based on insignificant changes to RSSI
 
 ## [0.6.4] - 2018-08-02
 ### Added


### PR DESCRIPTION
Fixes #171

This adds an optional parameter, `throttleRSSIDelta` to `scan` that defaults to the current value of 5, but allows users to increase or decrease the value to change how often repeat discoveries are reported. Setting the value to 0 will disable the check completely, since we're comparing the absolute value of the change in RSSI.

I'm not wild about the name of the parameter, `throttleRSSIDelta`, if someone's got a better suggestion I would gladly change it.