### PR TITLE
Allow checking is bluetooth available before starting Bluejay

### DIFF
--- a/Bluejay/Bluejay/Bluejay.swift
+++ b/Bluejay/Bluejay/Bluejay.swift
@@ -65,7 +65,11 @@ public class Bluejay: NSObject {
     
     /// Allows checking whether Bluetooth is powered on.
     public var isBluetoothAvailable: Bool {
-        return cbCentralManager.state == .poweredOn
+        if cbCentralManager == nil {
+            return false
+        } else {
+            return cbCentralManager.state == .poweredOn
+        }
     }
 
     /// Allows checking for if CoreBluetooth state is transitional (update is imminent)


### PR DESCRIPTION
### Fixes #:
- Crash when using `isBluetoothAvailable` prior to calling `start` on a Bluejay instance

### Summary of Problem:
- Need to be able to check that boolean before starting a Bluejay instance, #116

### Proposed Solution:
- Return false if Bluejay's central manager is nil and not yet initialized

### Testing Completed and Required:
- Tested using the demo app and debugPrint the boolean before calling start
  - No longer crashes and returns false