### PR TITLE
-Fix for crashes when listening on multiple characteristics

### DIFF
--- a/Bluejay/Bluejay/ListenCharacteristic.swift
+++ b/Bluejay/Bluejay/ListenCharacteristic.swift
@@ -88,9 +88,7 @@ class ListenCharacteristic: Operation {
             updateQueue()
         }
         else {
-            preconditionFailure(
-                "Expecting notification state update to charactersitic: \(characteristicIdentifier.uuid), but received event: \(event)"
-            )
+            log("Expecting notification state update to charactersitic: \(characteristicIdentifier.uuid), but received event: \(event)")
         }
     }
     


### PR DESCRIPTION
### Fixes #:
This fixes the situation where a didReadCharacteristic, event comes in on a characteristic that is already being "listened" on.  

### Summary of Problem:

I am not sure why this was happening as I am not reading after setting up the listener, but I suspect it may be a situation related to having multiple listeners.  Also, it could be that iOS is querying the battery service, of the connected peripheral.  In any case, the preconditionFailure causes the app to crash, which is not desirable. 

### Proposed Solution:

 If anything perhaps a custom error should be raised within Bluejay, but not a crash.

### Testing Completed and Required:


### Screenshots:
