### PR TITLE
v0.8.3 - Fix unpairing crash

### DIFF
--- a/Bluejay.podspec
+++ b/Bluejay.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |spec|
   spec.name = 'Bluejay'
-  spec.version = '0.8.2'
+  spec.version = '0.8.3'
   spec.license = { type: 'MIT', file: 'LICENSE' }
   spec.homepage = 'https://github.com/steamclock/bluejay'
   spec.authors = { 'Jeremy Chiang' => 'jeremy@steamclock.com' }
   spec.summary = 'Bluejay is a simple Swift framework for building reliable Bluetooth apps.'
   spec.homepage = 'https://github.com/steamclock/bluejay'
-  spec.source = { git: 'https://github.com/steamclock/bluejay.git', tag: 'v0.8.2' }
+  spec.source = { git: 'https://github.com/steamclock/bluejay.git', tag: 'v0.8.3' }
   spec.source_files = 'Bluejay/Bluejay/*.{h,swift}'
   spec.framework = 'SystemConfiguration'
   spec.platform = :ios, '10.0'

--- a/Bluejay/.jazzy.yaml
+++ b/Bluejay/.jazzy.yaml
@@ -2,7 +2,7 @@ output: ../docs
 author: Steamclock Software
 author_url: http://steamclock.com
 module: Bluejay
-module_version: 0.8.2
+module_version: 0.8.3
 readme: ../README.md
 sdk: iphone
 copyright: Copyright © 2017 Steamclock Software. All rights reserved.

--- a/Bluejay/Bluejay/Bluejay.swift
+++ b/Bluejay/Bluejay/Bluejay.swift
@@ -1402,7 +1402,9 @@ extension Bluejay: CBCentralManagerDelegate {
                     debugLog("Disconnect clean up: delivering expected disconnected event back to the pending connection in the queue...")
 
                     if let connection = weakSelf.queue.first as? Connection {
-                        if case let .stopping(error) = connection.state {
+                        if case .running = connection.state {
+                            connectingError = BluejayError.unexpectedDisconnect
+                        } else if case let .stopping(error) = connection.state {
                             connectingError = error
                         }
                     }

--- a/Bluejay/Bluejay/Info.plist
+++ b/Bluejay/Bluejay/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.8.2</string>
+	<string>0.8.3</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Bluejay/BluejayHeartSensorDemo/SensorViewController.swift
+++ b/Bluejay/BluejayHeartSensorDemo/SensorViewController.swift
@@ -18,6 +18,10 @@ let chirpCharacteristic = CharacteristicIdentifier(
     uuid: "83B4A431-A6F1-4540-B3EE-3C14AEF71A04",
     service: ServiceIdentifier(uuid: "CED261B7-F120-41C8-9A92-A41DE69CF2A8")
 )
+let pairingCharacteristic = CharacteristicIdentifier(
+    uuid: "E4D4A76C-B9F1-422F-8BBA-18508356A145",
+    service: ServiceIdentifier(uuid: "16274BFE-C539-416C-9646-CA3F991DADD6")
+)
 
 class SensorViewController: UITableViewController {
 
@@ -55,7 +59,7 @@ class SensorViewController: UITableViewController {
         if section == 0 {
             return 3
         } else {
-            return 7
+            return 8
         }
     }
 
@@ -104,6 +108,8 @@ class SensorViewController: UITableViewController {
                 cell.textLabel?.text = "Stop listening to Dittojay"
             } else if indexPath.row == 6 {
                 cell.textLabel?.text = "Terminate app"
+            } else if indexPath.row == 7 {
+                cell.textLabel?.text = "Pair"
             }
 
             return cell
@@ -138,6 +144,15 @@ class SensorViewController: UITableViewController {
                 endListen(to: chirpCharacteristic)
             } else if indexPath.row == 6 {
                 kill(getpid(), SIGKILL)
+            } else if indexPath.row == 7 {
+                bluejay.read(from: pairingCharacteristic) { (result: ReadResult<Data>) in
+                    switch result {
+                    case .success(let data):
+                        bluejay.log("Pairing success: \(String(data: data, encoding: .utf8) ?? "")")
+                    case .failure(let error):
+                        bluejay.log("Pairing failed with error: \(error.localizedDescription)")
+                    }
+                }
             }
 
             tableView.deselectRow(at: indexPath, animated: true)


### PR DESCRIPTION
Fixes: #198 

@kylebrowning could you also review this PR? Thanks 👍🏻

## Summary
This fix allows Bluejay to complete the disconnection clean up without crashing when a device is unpaired.

## Solution
I've never triggered iOS' system pairing dialog before with Bluejay, because I've never worked with a characteristic that is encrypted, since most of our client projects deal with authentication upfront, not on per-characteristic basis.

But I agree this can be common, so this fix is important.

Anyhow, I didn't know we can also get a disconnection event while the connection operation is in the `running` state, which is exactly what happens when:
1. Bluejay is attempting to reconnect
2. If you unpair the device during a reconnect attempt

This fix simply adds that specific case, and provide the missing `connectingError` using `BluejayError.unexpectedDisconnect`

```
if wasConnecting {
    debugLog("Disconnect clean up: delivering expected disconnected event back to the pending connection in the queue...")

    if let connection = weakSelf.queue.first as? Connection {
        if case .running = connection.state {
            connectingError = BluejayError.unexpectedDisconnect
        } else if case let .stopping(error) = connection.state {
            connectingError = error
        }
    }

}
```

## Notes
- I've added basic ways to test pairing and unpairing in our demo apps
 - You must accept pairing on both BluejayDemo and DittojayDemo to complete the pairing process
- You cannot test iOS pairing using the demos if both of your devices are logged into the same iCloud account (surprise 🤭)
- This fix might also cover some other unknown crashes related to unexpected disconnections during a connection
- This fix may not cover all crashes related to pairing and unpairing