### PR TITLE
Fix disconnect then scan crash

### DIFF
--- a/Bluejay.podspec
+++ b/Bluejay.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |spec|
   spec.name = 'Bluejay'
-  spec.version = '0.8.3'
+  spec.version = '0.8.4'
   spec.license = { type: 'MIT', file: 'LICENSE' }
   spec.homepage = 'https://github.com/steamclock/bluejay'
   spec.authors = { 'Jeremy Chiang' => 'jeremy@steamclock.com' }
   spec.summary = 'Bluejay is a simple Swift framework for building reliable Bluetooth apps.'
   spec.homepage = 'https://github.com/steamclock/bluejay'
-  spec.source = { git: 'https://github.com/steamclock/bluejay.git', tag: 'v0.8.3' }
+  spec.source = { git: 'https://github.com/steamclock/bluejay.git', tag: 'v0.8.4' }
   spec.source_files = 'Bluejay/Bluejay/*.{h,swift}'
   spec.framework = 'SystemConfiguration'
   spec.platform = :ios, '10.0'

--- a/Bluejay/.jazzy.yaml
+++ b/Bluejay/.jazzy.yaml
@@ -2,7 +2,7 @@ output: ../docs
 author: Steamclock Software
 author_url: http://steamclock.com
 module: Bluejay
-module_version: 0.8.3
+module_version: 0.8.4
 readme: ../README.md
 sdk: iphone
 copyright: Copyright © 2017 Steamclock Software. All rights reserved.

--- a/Bluejay/Bluejay/Info.plist
+++ b/Bluejay/Bluejay/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.8.3</string>
+	<string>0.8.4</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Bluejay/Bluejay/Queue.swift
+++ b/Bluejay/Bluejay/Queue.swift
@@ -55,12 +55,13 @@ class Queue {
             preconditionFailure("Cannot enqueue: Bluejay instance is nil.")
         }
 
+        queueable.queue = self
+
         if isDisconnectionQueued {
             queueable.fail(BluejayError.disconnectQueued)
             return
         }
 
-        queueable.queue = self
         queue.append(queueable)
 
         /*


### PR DESCRIPTION
Fixes: #196 

Thanks for the great bug report @jeffbk and @kylebrowning

Failing a queueable requires updating its queue, and therefore requires the queueable to have a reference to its queue. The disconnection-is-queued failure block is relatively new, so I didn't catch the new requirement - that is to shuffle the queue assignment to the new starting point of the add call.

This should fix specifically the crashes when you make Bluejay calls right after and during a queued disconnect, such as making a scan call right after the disconnect call.

However, I am not sure I fully understand this question:

> However, there is an additional issue that the startScan will fail because a disconnect is queued. It seems like this logic is misplaced as the Queue does not know wether the Queueable should fail when a disconnect is queued.