### PR TITLE
Update Bluejay.swift

### DIFF
--- a/Bluejay/Bluejay/Bluejay.swift
+++ b/Bluejay/Bluejay/Bluejay.swift
@@ -361,11 +361,13 @@ public class Bluejay: NSObject { //swiftlint:disable:this type_body_length
             debugLog("CBCentralManager initialized.")
         case .use(let manager, let peripheral):
             cbCentralManager = manager
-
+            // restoring delegation with cental manger
+            cbCentralManager.delegate = self
             if let peripheral = peripheral {
                 connectedPeripheral = Peripheral(delegate: self, cbPeripheral: peripheral)
                 peripheral.delegate = connectedPeripheral
             }
+            queue.start()
         }
 
         debugLog("Bluejay with UUID: \(uuid.uuidString) started.")


### PR DESCRIPTION
### Fixes #119 
Fixed bug in start with mode .use (added missing restoration  centralManager delegate) and then added queue.start()
### Summary of Problem:
There is a missing delegation restoration when using start with mode .use 
(we were forced to use start with mode .use because in iOS 13 bluejay.start() and connect() no longer work after another cbCentralManager has completed a scan (prior to iOS13, another scan with another cbCentralManager was not required )
For further info about this issue, feel free to contact me.
### Proposed Solution:
When recycling a cbCentralManager we need to restore its delegation to bluejay.
Also it is necessary to add queue.start() to solve the issue in #119 "Queue is paused because CBCentralManager is not ready yet" as @JeremyChiang proposed.

### Testing Completed and Required:

### Screenshots:
