### PR TITLE
[223] Make sure the library, bluejay demo, and dittojay demo build and run on Xcode 11 and later

### DIFF
--- a/Bluejay.podspec
+++ b/Bluejay.podspec
@@ -1,15 +1,15 @@
 Pod::Spec.new do |spec|
   spec.name = 'Bluejay'
-  spec.version = '0.8.5'
+  spec.version = '0.8.6'
   spec.license = { type: 'MIT', file: 'LICENSE' }
   spec.homepage = 'https://github.com/steamclock/bluejay'
   spec.authors = { 'Jeremy Chiang' => 'jeremy@steamclock.com' }
   spec.summary = 'Bluejay is a simple Swift framework for building reliable Bluetooth apps.'
   spec.homepage = 'https://github.com/steamclock/bluejay'
-  spec.source = { git: 'https://github.com/steamclock/bluejay.git', tag: 'v0.8.5' }
+  spec.source = { git: 'https://github.com/steamclock/bluejay.git', tag: 'v0.8.6' }
   spec.source_files = 'Bluejay/Bluejay/*.{h,swift}'
   spec.framework = 'SystemConfiguration'
-  spec.platform = :ios, '10.0'
+  spec.platform = :ios, '11.0'
   spec.requires_arc = true
   spec.dependency 'XCGLogger', '~> 7.0.0'
   spec.swift_version = '5.0'

--- a/Bluejay/Bluejay.xcodeproj/project.pbxproj
+++ b/Bluejay/Bluejay.xcodeproj/project.pbxproj
@@ -1130,8 +1130,10 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.steamclock.Bluejay;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Debug;
 		};
@@ -1155,7 +1157,9 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.steamclock.Bluejay;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Release;
 		};

--- a/Bluejay/Bluejay.xcodeproj/project.pbxproj
+++ b/Bluejay/Bluejay.xcodeproj/project.pbxproj
@@ -1124,7 +1124,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Bluejay/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MARKETING_VERSION = 0.8.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.steamclock.Bluejay;
@@ -1151,7 +1151,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Bluejay/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MARKETING_VERSION = 0.8.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.steamclock.Bluejay;

--- a/Bluejay/Bluejay.xcodeproj/project.pbxproj
+++ b/Bluejay/Bluejay.xcodeproj/project.pbxproj
@@ -1126,6 +1126,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MARKETING_VERSION = 0.8.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.steamclock.Bluejay;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1150,6 +1151,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MARKETING_VERSION = 0.8.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.steamclock.Bluejay;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/Bluejay/Bluejay/Info.plist
+++ b/Bluejay/Bluejay/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.8.5</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Bluejay/DittojayHeartSensorDemo/Info.plist
+++ b/Bluejay/DittojayHeartSensorDemo/Info.plist
@@ -43,7 +43,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>NSBluetoothPeripheralUsageDescription</key>
+	<key>NSBluetoothAlwaysUsageDescription</key>
 	<string>Allow Dittojay to stay connected when it is backgrounded.</string>
 </dict>
 </plist>

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ Bluejay's primary goals are:
 
 ## Requirements
 
-- iOS 10 or above
-- Xcode 10.2.1 or above
+- iOS 11 or above
+- Xcode 11.3.1 or above
 - Swift 5 or above
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ Bluejay's primary goals are:
 
 ## Requirements
 
-- iOS 11 or above
-- Xcode 11.3.1 or above
-- Swift 5 or above
+- iOS 11 or later recommended
+- Xcode 11.3.1 or later recommended
+- Swift 5 or later recommended
 
 ## Installation
 


### PR DESCRIPTION
## For #223

## Summary
We need to try running our library and demos using the latest Xcode, and make sure the basic Bluetooth operations still work on iOS 13.

## Solution & Testing
Tested everything on iOS 13, and found and fixed a crash related to Bluetooth privacy statement. Also verified all basic Bluetooth operations such as scanning, reading, and writing still work as expected.