### PR TITLE
Add Swift Package Manager support

### DIFF
--- a/Bluejay.podspec
+++ b/Bluejay.podspec
@@ -1,12 +1,12 @@
 Pod::Spec.new do |spec|
   spec.name = 'Bluejay'
-  spec.version = '0.8.6'
+  spec.version = '0.8.7'
   spec.license = { type: 'MIT', file: 'LICENSE' }
   spec.homepage = 'https://github.com/steamclock/bluejay'
   spec.authors = { 'Jeremy Chiang' => 'jeremy@steamclock.com' }
   spec.summary = 'Bluejay is a simple Swift framework for building reliable Bluetooth apps.'
   spec.homepage = 'https://github.com/steamclock/bluejay'
-  spec.source = { git: 'https://github.com/steamclock/bluejay.git', tag: 'v0.8.6' }
+  spec.source = { git: 'https://github.com/steamclock/bluejay.git', tag: 'v0.8.7' }
   spec.source_files = 'Bluejay/Bluejay/*.{h,swift}'
   spec.framework = 'SystemConfiguration'
   spec.platform = :ios, '11.0'

--- a/Bluejay/.jazzy.yaml
+++ b/Bluejay/.jazzy.yaml
@@ -2,7 +2,7 @@ output: ../docs
 author: Steamclock Software
 author_url: http://steamclock.com
 module: Bluejay
-module_version: 0.8.5
+module_version: 0.8.7
 readme: ../README.md
 sdk: iphone
 copyright: Copyright © 2017 Steamclock Software. All rights reserved.

--- a/Bluejay/Bluejay.xcodeproj/project.pbxproj
+++ b/Bluejay/Bluejay.xcodeproj/project.pbxproj
@@ -1126,7 +1126,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 0.8.6;
+				MARKETING_VERSION = 0.8.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.steamclock.Bluejay;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -1153,7 +1153,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MARKETING_VERSION = 0.8.6;
+				MARKETING_VERSION = 0.8.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.steamclock.Bluejay;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/Bluejay/Bluejay/BackgroundRestoreConfig.swift
+++ b/Bluejay/Bluejay/BackgroundRestoreConfig.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 /// Contains all required configurations for background restoration.
 public struct BackgroundRestoreConfig {

--- a/Bluejay/Bluejay/BackgroundRestorer.swift
+++ b/Bluejay/Bluejay/BackgroundRestorer.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 /**
  * Protocols for handling the results of a background restoration.

--- a/Bluejay/Bluejay/Bluejay.swift
+++ b/Bluejay/Bluejay/Bluejay.swift
@@ -6,8 +6,9 @@
 //  Copyright © 2017 Steamclock Software. All rights reserved.
 //
 
-import CoreBluetooth
 import Foundation
+import UIKit
+import CoreBluetooth
 import XCGLogger
 
 /**

--- a/Bluejay/Bluejay/ListenRestorer.swift
+++ b/Bluejay/Bluejay/ListenRestorer.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 
 /**
  * Protocol for handling a listen event that does not have a callback due to background restoration.

--- a/Bluejay/Bluejay/Scan.swift
+++ b/Bluejay/Bluejay/Scan.swift
@@ -8,6 +8,7 @@
 
 import CoreBluetooth
 import Foundation
+import UIKit
 
 /// A scan operation.
 class Scan: Queueable {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Changed
 
+## [0.8.7] - 2020-05-11
+### Added
+- Added support for Swift Package Manager
+
 ## [0.8.6] - 2020-02-03
 ### Changed
 - Bumped iOS target to 11 and recommended Xcode to 11.3.1

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version:5.1
+
+import PackageDescription
+
+let package = Package(
+    name: "Bluejay",
+    platforms: [
+        .iOS(.v11),
+    ],
+    products: [
+        .library(
+            name: "Bluejay",
+            targets: ["Bluejay"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/DaveWoodCom/XCGLogger", from: "7.0.0"),
+    ],
+    targets: [
+        .target(
+            name: "Bluejay",
+            dependencies: ["XCGLogger"],
+            path: "Bluejay/Bluejay"),
+    ],
+    swiftLanguageVersions: [.v5]
+)


### PR DESCRIPTION
This PR adds support for [Swift Package Manager](https://swift.org/package-manager/) which is now built into Xcode. It required adding `import UIKit` anywhere that those functions were called but otherwise caused no other changes.