### PR TITLE
Fix already connected pheriperal after restoration

### DIFF
--- a/Bluejay/Bluejay/Bluejay.swift
+++ b/Bluejay/Bluejay/Bluejay.swift
@@ -1305,6 +1305,10 @@ extension Bluejay: CBCentralManagerDelegate {
 
         connectingCallback = nil
 
+        let wasConnected = isConnected
+
+        debugLog("Central manager connected to perihperal already: \(wasConnected)")
+
         connectedPeripheral = connectingPeripheral ?? connectedPeripheral
         connectingPeripheral = nil
 
@@ -1315,6 +1319,10 @@ extension Bluejay: CBCentralManagerDelegate {
 
         if queue.first is Connection {
             queue.process(event: .didConnectPeripheral(connectedPeripheral!), error: nil)
+        }
+
+        guard !wasConnected else {
+            return
         }
 
         for observer in connectionObservers {

--- a/Bluejay/Bluejay/Bluejay.swift
+++ b/Bluejay/Bluejay/Bluejay.swift
@@ -1305,7 +1305,7 @@ extension Bluejay: CBCentralManagerDelegate {
 
         connectingCallback = nil
 
-        connectedPeripheral = connectingPeripheral
+        connectedPeripheral = connectingPeripheral ?? connectedPeripheral
         connectingPeripheral = nil
 
         precondition(connectedPeripheral != nil, "Connected peripheral is assigned a nil value despite Bluejay has successfully finished a connection.")
@@ -1313,7 +1313,9 @@ extension Bluejay: CBCentralManagerDelegate {
         shouldAutoReconnect = true
         debugLog("Should auto-reconnect: \(shouldAutoReconnect)")
 
-        queue.process(event: .didConnectPeripheral(connectedPeripheral!), error: nil)
+        if queue.first is Connection {
+            queue.process(event: .didConnectPeripheral(connectedPeripheral!), error: nil)
+        }
 
         for observer in connectionObservers {
             observer.weakReference?.connected(to: connectedPeripheral!.identifier)


### PR DESCRIPTION
### Fixes #206:

### Summary of Problem:

In case of device already being connected during restoration phase in `CBCentralManagerDelegate.centralManager(_ central: CBCentralManager, willRestoreState dict: [String: Any])` Bluejay assign connected device to `connectedPeripheral`. It breaks further logic as Bluejay didn't start connection explicitly yet `CBCentralManagerDelegate.centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral)` will be called along the road, which leads to precondition fatal error due to lack of `connectingPeripheral`.

### Proposed Solution:

I assume that while Bluejay have already `connectedPeripheral` it is enough to fill missing gap by assigning it to `connectingPeripheral`. In addition i'm checking current queue task to not break further processing.

As i'm not familiar with the codebase very well i tried to patch the problem with as less as possible changes, but i can imagine that's not perfect and can lead to some unknown to me side effects, so really appreciate any feedback to this PR.

In next week i will probably do more tests around this patch so maybe sth else will came up;)
