### PR TITLE
Fix problems with timeouts on listens not working as expected with partial data received or data overflow

### DIFF
--- a/Bluejay/Bluejay/Error.swift
+++ b/Bluejay/Bluejay/Error.swift
@@ -66,6 +66,8 @@ public enum BluejayError {
     case multipleListenTrapped
     /// The original listen declared that it can be replaced by a new listen.
     case multipleListenReplaced
+    /// An operation expecting a certain amount of data (i.e. writeAndAssemble received more than expected)
+    case tooMuchData(expected: Int, received: Data)
 }
 
 extension BluejayError: LocalizedError {
@@ -131,6 +133,8 @@ extension BluejayError: LocalizedError {
             return "The current listen cannot be installed because an existing listen on the same characteristic is configured to trap"
         case .multipleListenReplaced:
             return "The current listen has been replaced by a newer listen on the same characteristic"
+        case .tooMuchData(let expected, let received):
+            return "More data than expected was received from the device (expected: \(expected), got: \(received.count))"
         }
     }
 }
@@ -171,6 +175,7 @@ extension BluejayError: CustomNSError {
         case .startupBackgroundTaskExpired: return 26
         case .multipleListenTrapped: return 27
         case .multipleListenReplaced: return 28
+        case .tooMuchData: return 29
         }
     }
 


### PR DESCRIPTION
### For #240, #242

### Summary of Problem:

There were a couple of rare error states that could happen if timeouts happened in the middle of a multi part listen, or if writeAndAssemble received more data than expected that were not being handled correctly (could fail to throw an error, could leave the bluetooth stack in a weird state where late operations would fail).

### Proposed Solution:

- Throw a new `.tooMuchData` error for writeAndAssemble if the data overflows the expected length
- If the wait inside a synchronous background listen (listen, writeAndListen, writeAndAssemble) times out, always treat it as an error, even if there has also been some successful receipt of data.

### Testing Completed and Required:

Verified the behaviour of all the failure modes for write and assemble inside another app. The error edge cases for this are strange enough that it is a little tricky to test them in the real world, writeAndAssemble can be tested artificially by lying about the expected amount of data, but its not clear how to verify the correct behaviour of listen and writeAndListen without hardware that causes the behaviour. The changes are relatively low risk though, given the the changes are identical to writeAndListen, which CAN be tested.
