### PR TITLE
Add setting to broadcast errors sent to cancelEverything to all listeners

### DIFF
--- a/Bluejay/Bluejay/Bluejay.swift
+++ b/Bluejay/Bluejay/Bluejay.swift
@@ -163,6 +163,14 @@ public class Bluejay: NSObject { //swiftlint:disable:this type_body_length
         return restoreIdentifier != nil
     }
 
+    /// Enables disconnection errors or arguments to "cancelEverything" also being broadcast to active listeners, to allow them to perform cleanup or shutdown
+    /// operations.
+    ///
+    /// Note: Currently defaults to false, to match original behaviour, because this could be quite disruptive to code that was written assuming this isn't true.
+    /// Arguably should default to true, since there are some situations (such listens in background tasks without timeouts) where this is required for correct
+    /// behaviour, and it may change eventually.
+    public var broadcastErrorsToListeners: Bool = false
+
     // MARK: - Logging
 
     /**
@@ -337,6 +345,7 @@ public class Bluejay: NSObject { //swiftlint:disable:this type_body_length
             debugLog("Should auto-reconnect: \(shouldAutoReconnect)")
         }
 
+        connectedPeripheral?.broadcastErrorToListeners(error)
         queue.cancelAll(error: error)
 
         if isConnected && shouldDisconnect {

--- a/Bluejay/Bluejay/Bluejay.swift
+++ b/Bluejay/Bluejay/Bluejay.swift
@@ -345,7 +345,9 @@ public class Bluejay: NSObject { //swiftlint:disable:this type_body_length
             debugLog("Should auto-reconnect: \(shouldAutoReconnect)")
         }
 
-        connectedPeripheral?.broadcastErrorToListeners(error)
+        if broadcastErrorsToListeners {
+            connectedPeripheral?.broadcastErrorToListeners(error)
+        }
         queue.cancelAll(error: error)
 
         if isConnected && shouldDisconnect {

--- a/Bluejay/Bluejay/Peripheral.swift
+++ b/Bluejay/Bluejay/Peripheral.swift
@@ -263,6 +263,10 @@ class Peripheral: NSObject {
         }
     }
 
+    func broadcastErrorToListeners(_ error: Error) {
+        listeners.values.forEach { $0.0?(.failure(error)) }
+    }
+    
     /// Ask for the peripheral's maximum payload length in bytes for a single write request.
     public func maximumWriteValueLength(`for` writeType: CBCharacteristicWriteType) -> Int {
         return cbPeripheral.maximumWriteValueLength(for: writeType)


### PR DESCRIPTION


### Fixes #239 (also helps with workarounds for #240):

### Summary of Problem:

As detailed in #239, when you are in a background task, there are currently cases where you can end up unable to exit the task when you are in a blocking listen either due to a disconnection or (also) intentionally via calling cancelEverything, because none of the errors generated by that will propagate to the listeners, which we can be blocked on. This behaviour also causes problems with implementing your own timeouts to work around #240 (which is hard to fix within Bluejay due to the behaviour of the semaphore timeouts), because there is no way to implement a timeout at the application level if calling cancelEverything will not actually cancel _everything_.

### Proposed Solution:

Add an option to allow errors sent in to cancelEverything to be propagated to all current listeners, this will allow background tasks that are blocked on listeners to be intentionally cancelled via calling cancelEverything, and also implicitly handles unintentional disconnects (which also end up calling cancelEverything).

Although I think this setting probably should be the default, it could be very disruptive to anything doing non-background-task listens that wasn't written with this in mind, becasue you could get lots of spurious errors on the listeners, so having it explicitly enabled seems like the best approach for now.

