### PR TITLE
Add peripheralIsReady support for writes without response

### DIFF
--- a/Bluejay/Bluejay/Event.swift
+++ b/Bluejay/Bluejay/Event.swift
@@ -18,5 +18,6 @@ enum Event {
     case didDisconnectPeripheral(Peripheral)
     case didReadCharacteristic(CBCharacteristic, Data)
     case didWriteCharacteristic(CBCharacteristic)
+    case isReadyToWriteWithoutResponse
     case didUpdateCharacteristicNotificationState(CBCharacteristic)
 }

--- a/Bluejay/Bluejay/Peripheral.swift
+++ b/Bluejay/Bluejay/Peripheral.swift
@@ -295,6 +295,11 @@ extension Peripheral: CBPeripheralDelegate {
     public func peripheral(_ peripheral: CBPeripheral, didWriteValueFor characteristic: CBCharacteristic, error: Error?) {
         handle(event: .didWriteCharacteristic(characteristic), error: error as NSError?)
     }
+    
+    /// Captures CoreBluetooth's peripheral is ready to send write without response event and pass it to Bluejay's queue for processing.
+    func peripheralIsReady(toSendWriteWithoutResponse peripheral: CBPeripheral) {
+        handle(event: .isReadyToWriteWithoutResponse, error: nil)
+    }
 
     /// Captures CoreBluetooth's did receive a notification/value from a characteristic event and pass it to Bluejay's queue for processing.
     public func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {

--- a/Bluejay/Bluejay/WriteCharacteristic.swift
+++ b/Bluejay/Bluejay/WriteCharacteristic.swift
@@ -57,14 +57,19 @@ class WriteCharacteristic<T: Sendable>: Operation {
         peripheral.writeValue(value.toBluetoothData(), for: characteristic, type: type)
 
         debugLog("Started write to \(characteristicIdentifier.description) on \(peripheral.identifier).")
-
-        if type == .withoutResponse {
-            process(event: .didWriteCharacteristic(characteristic))
-        }
     }
 
     func process(event: Event) {
-        if case .didWriteCharacteristic(let wroteTo) = event {
+        if case .isReadyToWriteWithoutResponse = event {
+            state = .completed
+
+            debugLog("Write to \(characteristicIdentifier.description) on \(peripheral.identifier) is successful.")
+
+            callback?(.success)
+            callback = nil
+
+            updateQueue()
+        } else if case .didWriteCharacteristic(let wroteTo) = event {
             if wroteTo.uuid != characteristicIdentifier.uuid {
                 preconditionFailure("Expecting write to \(characteristicIdentifier.description), but actually wrote to \(wroteTo.uuid)")
             }


### PR DESCRIPTION
### Fixes [#250](https://github.com/steamclock/bluejay/issues/250):

### Summary of Problem:
The current solution assumes that write events without a response can automatically be processed however this isn't the case. If we have a large volume of writes without a response the will out grow the Core Bluetooth buffer if they are all processed immediately.

### Proposed Solution:
To mitigate against this issue apple have introduce the peripheralIsReady toSendWriteWithoutResponse delegate method. My proposed solution uses this method to determine when the write should be processed. I have introduced a new event type and pass it to the handler when the peripheralIsReady delegate method is called
