### PR TITLE
Fix compile error on Xcode 13 / iOS 15 SDK caused by an optionality change

### DIFF
--- a/Bluejay/Bluejay/CharacteristicIdentifier.swift
+++ b/Bluejay/Bluejay/CharacteristicIdentifier.swift
@@ -17,9 +17,16 @@ public struct CharacteristicIdentifier {
     /// The `CBUUID` of this characteristic.
     public let uuid: CBUUID
 
-    /// Create a `CharacteristicIdentifier` using a `CBCharacterstic`.
-    public init(_ cbCharacteristic: CBCharacteristic) {
-        self.service = ServiceIdentifier(uuid: cbCharacteristic.service.uuid)
+    /// Create a `CharacteristicIdentifier` using a `CBCharacterstic`. Creation will fail if the "service" property of the CBCharacteristic is nil.
+    /// Note: It isn't documented in CoreBluetooth under what circumstances that property might be nil, but it seems like it should almost never happen.
+    public init?(_ cbCharacteristic: CBCharacteristic) {
+        let optionalService: CBService? = cbCharacteristic.service // became optional with iOS 15 SDK, do a little dance to make it always optional so code below should compile on Xcode 12 or 13
+
+        guard let service = optionalService else {
+            return nil
+        }
+
+        self.service = ServiceIdentifier(uuid: service.uuid)
         self.uuid = cbCharacteristic.uuid
     }
 
@@ -46,7 +53,8 @@ public struct CharacteristicIdentifier {
 
     /// Check equality between a `CharacteristicIdentifier` and a `CBCharacterstic`.
     public static func == (lhs: CharacteristicIdentifier, rhs: CBCharacteristic) -> Bool {
-        return (lhs.uuid == rhs.uuid) && (lhs.service.uuid == rhs.service.uuid)
+        let optionalService: CBService? = rhs.service // became optional with iOS 15 SDK, do a little dance to make it always optional so code below should compile on Xcode 12 or 13
+        return (lhs.uuid == rhs.uuid) && (lhs.service.uuid == optionalService?.uuid)
     }
 }
 

--- a/Bluejay/Bluejay/Peripheral.swift
+++ b/Bluejay/Bluejay/Peripheral.swift
@@ -298,12 +298,15 @@ extension Peripheral: CBPeripheralDelegate {
 
     /// Captures CoreBluetooth's did receive a notification/value from a characteristic event and pass it to Bluejay's queue for processing.
     public func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
-        let characteristicIdentifier = CharacteristicIdentifier(characteristic)
+        guard let characteristicIdentifier = CharacteristicIdentifier(characteristic) else {
+            debugLog("Received value update for characteristic (\(characteristic.uuid.uuidString) without a valid service. Update will be ignored")
+            return
+        }
 
         guard let listener = listeners[characteristicIdentifier], let listenCallback = listener.0 else {
             if delegate.isReading(characteristic: characteristicIdentifier) {
                 handle(event: .didReadCharacteristic(characteristic, characteristic.value ?? Data()), error: error as NSError?)
-            } else if delegate.willEndListen(on: CharacteristicIdentifier(characteristic)) {
+            } else if delegate.willEndListen(on: characteristicIdentifier) {
                 debugLog("""
                     Received read event with value \(String(data: characteristic.value ?? Data(), encoding: .utf8) ?? "") \
                     on characteristic \(characteristic.debugDescription), \

--- a/Bluejay/BluejayHeartSensorDemo/Info.plist
+++ b/Bluejay/BluejayHeartSensorDemo/Info.plist
@@ -43,5 +43,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>Connect to the test device</string>
 </dict>
 </plist>


### PR DESCRIPTION
### For: #259

### Summary of Problem:

The library was not building on Xcode 13 / the iOS 15 SDK due to the service property of CBCharacteristic changed from a `CBService` to a `CBService?` in the iOS 15 SDK.

### Proposed Solution:

Change the `CharacteristicIdentifier` initializer that takes a `CBCharacteristic` to be fallible and to fail if the service property is missing, and then change the code in value receiving that used that constructor to ignore any incoming values on characteristics without a service and warn.

This seemed like the cleanest way to deal with this, some alternatives considered and rejected:
- Make the service property of `CharacteristicIdentifier` also optional
- Use a default value (0?) for service if it's missing.

Both of those suffer from the problem that, AFAICT logically a characteristic MUST have a service to be valid. The CoreBluetooth documentation doesn't specify under what circumstance you can get a nil service, but it seems like any characteristic that has a nil service is malformed in some way, since in theory the only way to obtain characteristics is FROM services. Not letting it construct an invalid CharacteristicIdentifier seems a better approach than having partially constructed invalid ones running around. If we can prove that there IS some valid circumstance where we want to represent a characteristic with a nil service, we should problaby switch to one of the other approaches. 

The demo code was also missing the Bluetooth privacy text for allowing bluetooth access, so wouldn't run on newer devices. This PR also includes an update for that. 

### Testing Completed and Required:

Verified that basic communication was still working correctly using the demo apps on Xcode 13 / iOS 15. Also verified that it still compiled correctly on Xcode 12 (but didn't specifically test that binary).
